### PR TITLE
Add MAINTAINERS.md to document maintainer roles

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,30 @@
+# Maintainers
+
+The general handling of Maintainer rights and all groups in this GitHub org is done in the https://github.com/hiero-ledger/governance repository.
+
+## Maintainer Scopes, GitHub Roles and GitHub Teams
+
+Maintainers are assigned the following scopes in this repository:
+
+| Scope               | Definition                        | GitHub Role | GitHub Team                 |
+| ------------------- | --------------------------------- | ----------- | --------------------------- |
+| project-maintainers | The Maintainers of the project    | Maintain    | `hiero-cli-maintainers`     |
+| tsc                 | The Hiero TSC                     | Maintain    | `tsc`                       |
+| github-maintainers  | The Maintainers of the github org | Maintain    | `github-maintainers`        |
+
+## Active Maintainers
+
+| Name                   | GitHub ID      | Scope              | LFID | Discord ID | Email | Company Affiliation  |
+|----------------------- | -------------- | ------------------ | ---- | ---------- | ----- | -------------------- |
+| Michiel Mulders        | michielmulders |                    |      |            |       | Hashgraph            |
+| Giuseppe Bertone       | Neurone        |                    |      |            |       | Hashgraph            |
+
+## Emeritus Maintainers
+
+| Name             | GitHub ID     | Scope               | LFID | Discord ID | Email | Company Affiliation  |
+|----------------- | ------------- | ------------------- | ---- | ---------- | ----- | -------------------- |
+| George Spasov    | Perseverance  | project-maintainers |      |            |       | Limechain            |
+
+## The Duties of a Maintainer
+
+Maintainers are expected to perform duties in alignment with **[Hiero-Ledger's defined maintainer guidelines](https://github.com/hiero-ledger/governance/blob/main/roles-and-groups.md#maintainers).**


### PR DESCRIPTION
This document outlines the roles, scopes, and responsibilities of maintainers within the project, including active and emeritus maintainers.
