### PR TITLE
feat(1031): Set default log_level in cfg to error

### DIFF
--- a/src/core/services/config/__tests__/unit/config-service.test.ts
+++ b/src/core/services/config/__tests__/unit/config-service.test.ts
@@ -33,7 +33,7 @@ describe('ConfigServiceImpl', () => {
           expect.objectContaining({
             name: 'log_level',
             type: 'enum',
-            value: 'info',
+            value: 'error',
             allowedValues: expect.any(Array),
           }),
           expect.objectContaining({
@@ -125,7 +125,7 @@ describe('ConfigServiceImpl', () => {
 
       const result = configService.getOption('log_level');
 
-      expect(result).toBe('info');
+      expect(result).toBe('error');
     });
 
     it('should return valid enum value', () => {

--- a/src/core/services/config/config-service.ts
+++ b/src/core/services/config/config-service.ts
@@ -34,7 +34,7 @@ const CONFIG_OPTIONS: Record<string, OptionSpec> = {
   },
   log_level: {
     type: 'enum',
-    default: 'info',
+    default: 'error',
     allowedValues: LOG_LEVEL_VALUES,
   },
   default_key_manager: {


### PR DESCRIPTION
Set the default logging level to "error" to avoid revealing all technical information that is not necessary for using the CLI to the user. Now the CLI only displays errors.