### PR TITLE
chore: improve dry run in release workflow

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -174,12 +174,8 @@ jobs:
       - name: Install Dependencies
         run: jf npm ci
 
-      - name: Set Publish Data
-        id: set-publish-data
-        run: |
-          VERSION=$(jq -r '.version' './package.json')
-          CLI_NPM_PACKAGE_NAME="hiero-ledger-hiero-cli-${VERSION}.tgz"
-          echo "artifact-name=${CLI_NPM_PACKAGE_NAME}" >> $GITHUB_OUTPUT
+      - name: Compile Code
+        run: npm run build
 
       - name: Publish Semantic Release
         env:
@@ -193,10 +189,27 @@ jobs:
         run:
           npx semantic-release
 
+      - name: Update Version for Dry Run
+        if: ${{ github.event.inputs.dry-run-enabled == 'true' }}
+        run: |
+          npm version ${{ needs.prepare-release.outputs.version }} --no-git-tag-version
+
+      - name: Set Publish Data
+        id: set-publish-data
+        run: |
+          VERSION=$(jq -r '.version' './package.json')
+          CLI_NPM_PACKAGE_NAME="hiero-ledger-hiero-cli-${VERSION}.tgz"
+          echo "artifact-name=${CLI_NPM_PACKAGE_NAME}" >> $GITHUB_OUTPUT
+
+      # Needed since semantic release dry-run won't pack the tarball
+      - name: Pack for Dry Run
+        if: ${{ github.event.inputs.dry-run-enabled == 'true' }}
+        run: |
+          npm pack --pack-destination ./dist
+
       # Upload the artifact
       - name: Upload Hiero CLI Package Artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: ${{ github.event.inputs.dry-run-enabled != 'true' && !cancelled() && !failure() }}
         with:
           name: cli-npm-package
           path: ./dist/${{ steps.set-publish-data.outputs.artifact-name }}
@@ -209,7 +222,6 @@ jobs:
   # Add a publishing job for Hiero CLI to npmjs
   publish-npm-package:
     name: Publish Hiero CLI NPM Package
-    if: ${{ github.event.inputs.dry-run-enabled != 'true' && !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     needs:
       - create-github-release
@@ -241,8 +253,11 @@ jobs:
       - name: Publish Hiero CLI NPM Package
         run: |
           args="--access=public"
-          package="${{ needs.create-github-release.outputs.npm-artifact-name }}"
+          if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
+            args="${args} --dry-run"
+          fi
 
+          package="${{ needs.create-github-release.outputs.npm-artifact-name }}"
           echo "::group::Publishing package: ${package} with args: ${args}"
           npm publish ${package} ${args}
           echo "::endgroup::"


### PR DESCRIPTION
## Description
Issue:
The dry run mode of semantic release only runs the `verifyRelease` step and skips the `prepare` and following steps. 
Per the [@semantic-release/npm docs](https://github.com/semantic-release/npm/blob/master/README.md#semantic-releasenpm), the `prepare` step is defined as the step where the package is supposedly built, which in our case wouldn't happen when doing a dry run.
This causes the workflow to fail on a dry run on the steps following the semantic release step because they reference a package which hasn't been built since the step is skipped.

This pull request changes the following:
Add conditions to steps referencing the package to only run when the workflow is not in dry-run mode.

### Related Issues

N/A
