### PR TITLE
ci(fix): support major releases in semantic release config

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,10 +3,7 @@
     [
       "@semantic-release/commit-analyzer",
       {
-        "preset": "conventionalcommits",
-        "releaseRules": [
-          { "breaking": true, "release": "minor" }
-        ]
+        "preset": "conventionalcommits"
       }
     ],
     [


### PR DESCRIPTION
## Description

This pull request changes the following:

- Goes back to the default releaseRules for the semantic-release/commit-analyzer plugin.

### Related Issues

- Closes #
