### PR TITLE
chore: update node to v22 in semantic release workflow

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -52,7 +52,7 @@ jobs:
           checkout-ref: '${{ github.ref }}'
           checkout-token: '${{ secrets.GH_ACCESS_TOKEN }}'
           setup-node: 'true'
-          node-version: '20'
+          node-version: '22'
           node-registry: 'https://registry.npmjs.org/'
 
       - name: Setup JQ
@@ -155,7 +155,7 @@ jobs:
           checkout-ref: '${{ github.ref }}'
           checkout-token: '${{ secrets.GH_ACCESS_TOKEN }}'
           setup-node: 'true'
-          node-version: '20'
+          node-version: '22'
           node-registry: 'https://registry.npmjs.org/'
 
       - name: Install GnuPG Tools


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates node to v22 inside the semantic release workflow since semantic-release v25 requires it at a minimum

### Related Issues

- Closes #
