### PR TITLE
fix(1718): Associate command runtime crash if already associated

### DIFF
--- a/src/plugins/token/__tests__/unit/associate.test.ts
+++ b/src/plugins/token/__tests__/unit/associate.test.ts
@@ -87,6 +87,70 @@ describe('tokenAssociateHandler', () => {
       expect(output.transactionId).toBeUndefined();
     });
 
+    test('should skip transaction pipeline when token is already associated', async () => {
+      const tokenId = '0.0.123456';
+      const accountId = '0.0.789012';
+
+      const createTokenAssociationTransaction = jest.fn();
+      const txSignSign = jest.fn();
+      const txExecuteExecute = jest.fn();
+
+      mockZustandTokenStateHelper(MockedHelper);
+
+      const { api } = makeApiMocks({
+        alias: {
+          resolve: jest.fn().mockReturnValue({
+            entityId: tokenId,
+          }),
+        },
+        mirror: {
+          getAccountTokenBalances: jest.fn().mockResolvedValue({
+            tokens: [{ token_id: tokenId, balance: 0 }],
+          }),
+        },
+        kms: {
+          importPrivateKey: jest.fn().mockReturnValue({
+            keyRefId: 'imported-key-ref-id',
+            publicKey: 'imported-public-key',
+          }),
+        },
+        tokenTransactions: {
+          createTokenAssociationTransaction,
+        },
+        txSign: {
+          sign: txSignSign,
+        },
+        txExecute: {
+          execute: txExecuteExecute,
+        },
+      });
+
+      const logger = makeLogger();
+      const args: CommandHandlerArgs = {
+        args: {
+          token: tokenId,
+          account: `${accountId}:3333333333333333333333333333333333333333333333333333333333333333`,
+        },
+        api,
+        state: api.state,
+        config: api.config,
+        logger,
+      };
+
+      const result = await tokenAssociate(args);
+
+      const output = assertOutput(result.result, TokenAssociateOutputSchema);
+      expect(output.tokenId).toBe(tokenId);
+      expect(output.accountId).toBe(accountId);
+      expect(output.associated).toBe(true);
+      expect(output.alreadyAssociated).toBe(true);
+      expect(output.transactionId).toBeUndefined();
+
+      expect(createTokenAssociationTransaction).not.toHaveBeenCalled();
+      expect(txSignSign).not.toHaveBeenCalled();
+      expect(txExecuteExecute).not.toHaveBeenCalled();
+    });
+
     test('should associate token with account using account-id:account-key format', async () => {
       const mockAddAssociation = jest.fn();
       const mockAssociationTransaction = { test: 'association-transaction' };

--- a/src/plugins/token/commands/associate/handler.ts
+++ b/src/plugins/token/commands/associate/handler.ts
@@ -42,6 +42,41 @@ export class TokenAssociateCommand extends BaseTransactionCommand<
     super(TOKEN_ASSOCIATE_COMMAND_NAME);
   }
 
+  override async execute(args: CommandHandlerArgs): Promise<CommandResult> {
+    const normalisedParams = await this.normalizeParams(args);
+
+    if (normalisedParams.alreadyAssociated) {
+      return this.executeAlreadyAssociated(args, normalisedParams);
+    }
+
+    return super.execute(args);
+  }
+
+  private async executeAlreadyAssociated(
+    args: CommandHandlerArgs,
+    normalisedParams: AssociateNormalizedParams,
+  ): Promise<CommandResult> {
+    const { api, logger } = args;
+    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    saveAssociationToState(
+      tokenState,
+      normalisedParams.tokenId,
+      normalisedParams.account.accountId,
+      normalisedParams.network,
+      logger,
+    );
+
+    const outputData: TokenAssociateOutput = {
+      accountId: normalisedParams.account.accountId,
+      tokenId: normalisedParams.tokenId,
+      associated: true,
+      alreadyAssociated: true,
+      network: normalisedParams.network,
+    };
+
+    return { result: outputData };
+  }
+
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<AssociateNormalizedParams> {
@@ -101,9 +136,6 @@ export class TokenAssociateCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: AssociateNormalizedParams,
   ): Promise<AssociateBuildTransactionResult> {
-    if (normalisedParams.alreadyAssociated) {
-      return {};
-    }
     const { api } = args;
     const transaction = api.token.createTokenAssociationTransaction({
       tokenId: normalisedParams.tokenId,
@@ -117,18 +149,15 @@ export class TokenAssociateCommand extends BaseTransactionCommand<
     normalisedParams: AssociateNormalizedParams,
     buildTransactionResult: AssociateBuildTransactionResult,
   ): Promise<AssociateSignTransactionResult> {
-    if (!buildTransactionResult.transaction) {
-      return {};
-    }
     const { api, logger } = args;
     logger.debug(
       `Using key ${normalisedParams.account.keyRefId} for signing transaction`,
     );
-    const transaction = await api.txSign.sign(
+    const signedTransaction = await api.txSign.sign(
       buildTransactionResult.transaction,
       [normalisedParams.account.keyRefId],
     );
-    return { signedTransaction: transaction };
+    return { signedTransaction };
   }
 
   async executeTransaction(
@@ -137,13 +166,6 @@ export class TokenAssociateCommand extends BaseTransactionCommand<
     _buildTransactionResult: AssociateBuildTransactionResult,
     signTransactionResult: AssociateSignTransactionResult,
   ): Promise<AssociateExecuteTransactionResult> {
-    if (
-      normalisedParams.alreadyAssociated ||
-      !signTransactionResult.signedTransaction
-    ) {
-      return { alreadyAssociated: true };
-    }
-
     const { api } = args;
     try {
       const transactionResult = await api.txExecute.execute(

--- a/src/plugins/token/commands/associate/types.ts
+++ b/src/plugins/token/commands/associate/types.ts
@@ -16,11 +16,11 @@ export interface AssociateNormalizedParams extends BaseNormalizedParams {
 }
 
 export interface AssociateBuildTransactionResult {
-  transaction?: Transaction;
+  transaction: Transaction;
 }
 
 export interface AssociateSignTransactionResult {
-  signedTransaction?: Transaction;
+  signedTransaction: Transaction;
 }
 
 export interface AssociateExecuteTransactionResult {


### PR DESCRIPTION
#1718