### PR TITLE
fix(1793): make balance nullable in AccountListItemAPIResponse

### DIFF
--- a/src/core/services/mirrornode/__tests__/unit/hedera-mirrornode-service.test.ts
+++ b/src/core/services/mirrornode/__tests__/unit/hedera-mirrornode-service.test.ts
@@ -544,6 +544,24 @@ describe('HederaMirrornodeServiceDefaultImpl', () => {
       );
     });
 
+    it('should handle account with null balance (balance=false query)', async () => {
+      const { service } = setupService();
+      const mockAccount = createMockAccountListItemAPIResponse({
+        balance: null,
+      });
+      const mockResponse = createMockGetAccountsAPIResponse([mockAccount]);
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const result = await service.getAccounts({ balance: false });
+
+      expect(result.accounts).toHaveLength(1);
+      expect(result.accounts[0].accountId).toBe(mockAccount.account);
+      expect(result.accounts[0].balance).toBeUndefined();
+    });
+
     it('should return empty list on HTTP 404', async () => {
       const { service } = setupService();
       (global.fetch as jest.Mock).mockResolvedValue({


### PR DESCRIPTION
## Description

This pull request changes the following:

- Make `balance` nullable in `AccountListItemAPIResponse` to handle Mirror Node returning `null` when `balance=false` is queried
- Add unit test covering the `balance: null` case in `getAccounts`

Unit tests added in `hedera-mirrornode-service.test.ts` — all 65 tests pass.

### Related Issues

- Closes #1793
