### PR TITLE
feat(1783): split name field into name and tokenName in token file sc…

### DIFF
--- a/examples/token/nft-full-example.json
+++ b/examples/token/nft-full-example.json
@@ -1,5 +1,6 @@
 {
   "name": "nft-full-example",
+  "tokenName": "NFT Full Example",
   "symbol": "NFE",
   "supplyType": "finite",
   "maxSupply": 10000,
@@ -12,5 +13,8 @@
   "pauseKey": "<alias or accountId:privateKey>",
   "feeScheduleKey": "<alias or accountId:privateKey>",
   "memo": "Full example NFT with all fields",
-  "associations": ["<alias or accountId:privateKey>", "..."]
+  "associations": [
+    "<alias or accountId:privateKey>",
+    "..."
+  ]
 }

--- a/examples/token/nft-with-aliases.json
+++ b/examples/token/nft-with-aliases.json
@@ -1,5 +1,6 @@
 {
   "name": "nft-aliases-example",
+  "tokenName": "NFT Aliases Example",
   "symbol": "NAL",
   "supplyType": "infinite",
   "treasuryKey": "treasuryAccount",

--- a/examples/token/nft-with-keys.json
+++ b/examples/token/nft-with-keys.json
@@ -1,5 +1,6 @@
 {
   "name": "nft-keys-example",
+  "tokenName": "NFT Keys Example",
   "symbol": "NKE",
   "supplyType": "infinite",
   "treasuryKey": "<alias or accountId:privateKey>",

--- a/examples/token/token-fixed-fee-hbar.json
+++ b/examples/token/token-fixed-fee-hbar.json
@@ -1,5 +1,6 @@
 {
   "name": "token-fixed-fee-hbar",
+  "tokenName": "Token Fixed Fee HBAR",
   "symbol": "FFHBAR",
   "decimals": 8,
   "supplyType": "finite",

--- a/examples/token/token-fixed-fee-token.json
+++ b/examples/token/token-fixed-fee-token.json
@@ -1,5 +1,6 @@
 {
   "name": "token-fixed-fee-token",
+  "tokenName": "Token Fixed Fee Token",
   "symbol": "FFTOK",
   "decimals": 8,
   "supplyType": "finite",

--- a/examples/token/token-fractional-fee-receiver-pays.json
+++ b/examples/token/token-fractional-fee-receiver-pays.json
@@ -1,5 +1,6 @@
 {
   "name": "token-fractional-receiver",
+  "tokenName": "Token Fractional Fee Receiver",
   "symbol": "FFRECV",
   "decimals": 8,
   "supplyType": "finite",

--- a/examples/token/token-fractional-fee-sender-pays.json
+++ b/examples/token/token-fractional-fee-sender-pays.json
@@ -1,5 +1,6 @@
 {
   "name": "token-fractional-sender",
+  "tokenName": "Token Fractional Fee Sender",
   "symbol": "FFSEND",
   "decimals": 8,
   "supplyType": "finite",

--- a/examples/token/token-full-example.json
+++ b/examples/token/token-full-example.json
@@ -1,5 +1,6 @@
 {
   "name": "token-full-example",
+  "tokenName": "Token Full Example",
   "symbol": "TFE",
   "decimals": 8,
   "supplyType": "finite",
@@ -16,7 +17,10 @@
   "memo": "Full example token with all fields",
   "autoRenewPeriod": "90d",
   "autoRenewAccount": "<alias or accountId:privateKey>",
-  "associations": ["<alias or accountId:privateKey>", "..."],
+  "associations": [
+    "<alias or accountId:privateKey>",
+    "..."
+  ],
   "customFees": [
     {
       "type": "fixed",

--- a/examples/token/token-with-aliases.json
+++ b/examples/token/token-with-aliases.json
@@ -1,5 +1,6 @@
 {
   "name": "token-aliases-example",
+  "tokenName": "Token Aliases Example",
   "symbol": "TAL",
   "decimals": 10,
   "supplyType": "infinite",

--- a/examples/token/token-with-base-units.json
+++ b/examples/token/token-with-base-units.json
@@ -1,5 +1,6 @@
 {
   "name": "token-base-units-example",
+  "tokenName": "Token Base Units Example",
   "symbol": "TBU",
   "decimals": 6,
   "supplyType": "finite",

--- a/examples/token/token-with-keys.json
+++ b/examples/token/token-with-keys.json
@@ -1,5 +1,6 @@
 {
   "name": "token-keys-example",
+  "tokenName": "Token Keys Example",
   "symbol": "TRK",
   "decimals": 10,
   "supplyType": "infinite",

--- a/src/plugins/token/__tests__/unit/helpers/fixtures.ts
+++ b/src/plugins/token/__tests__/unit/helpers/fixtures.ts
@@ -92,6 +92,7 @@ export const mockCredentials = {
  */
 export const validTokenFile = {
   name: 'TestToken',
+  tokenName: 'TestToken',
   symbol: 'TEST',
   decimals: 2,
   supplyType: 'finite' as const,
@@ -125,6 +126,7 @@ export const infiniteSupplyTokenFile = {
  * Invalid Token File - Missing Name
  */
 export const invalidTokenFileMissingName = {
+  tokenName: 'TestToken',
   symbol: 'TEST',
   decimals: 2,
   supplyType: 'finite' as const,
@@ -965,6 +967,7 @@ export const makeTokenMintNftCommandArgs = (params: {
  */
 export const validNftTokenFile = {
   name: 'TestNFT',
+  tokenName: 'TestNFT',
   symbol: 'TNFT',
   supplyType: 'finite',
   maxSupply: 1000,
@@ -980,6 +983,7 @@ export const validNftTokenFile = {
  */
 export const infiniteSupplyNftFile = {
   name: 'TestNFT',
+  tokenName: 'TestNFT',
   symbol: 'TNFT',
   supplyType: 'infinite',
   treasuryKey: `${mockAccountIds.treasury}:${mockKeys.treasury}`,
@@ -993,6 +997,7 @@ export const infiniteSupplyNftFile = {
  */
 export const invalidNftFileMissingSupplyKey = {
   name: 'TestNFT',
+  tokenName: 'TestNFT',
   symbol: 'TNFT',
   supplyType: 'infinite',
   treasuryKey: `${mockAccountIds.treasury}:${mockKeys.treasury}`,
@@ -1005,6 +1010,7 @@ export const invalidNftFileMissingSupplyKey = {
  */
 export const invalidNftFileFiniteWithoutMaxSupply = {
   name: 'TestNFT',
+  tokenName: 'TestNFT',
   symbol: 'TNFT',
   supplyType: 'finite',
   // maxSupply missing - should fail validation
@@ -1018,6 +1024,7 @@ export const invalidNftFileFiniteWithoutMaxSupply = {
  */
 export const invalidNftFileInfiniteWithMaxSupply = {
   name: 'TestNFT',
+  tokenName: 'TestNFT',
   symbol: 'TNFT',
   supplyType: 'infinite',
   maxSupply: 1000,
@@ -1030,6 +1037,7 @@ export const invalidNftFileInfiniteWithMaxSupply = {
  * Invalid NFT Token File - Missing Name
  */
 export const invalidNftFileWithoutName = {
+  tokenName: 'TestNFT',
   symbol: 'TNFT',
   supplyType: 'finite',
   treasuryKey: '0.0.123456:treasury-key',

--- a/src/plugins/token/__tests__/unit/schema.test.ts
+++ b/src/plugins/token/__tests__/unit/schema.test.ts
@@ -319,7 +319,8 @@ describe('Token Schema Validation', () => {
 
   describe('FungibleTokenFileSchema customFees max limit', () => {
     const baseToken = {
-      name: 'Test Token',
+      name: 'test-token',
+      tokenName: 'Test Token',
       symbol: 'TST',
       decimals: 8,
       supplyType: 'infinite',

--- a/src/plugins/token/commands/create-ft-from-file/handler.ts
+++ b/src/plugins/token/commands/create-ft-from-file/handler.ts
@@ -110,7 +110,7 @@ export class TokenCreateFtFromFileCommand extends BaseTransactionCommand<
       filename: validArgs.file,
       keyManager,
       alias: tokenDefinition.name,
-      name: tokenDefinition.name,
+      name: tokenDefinition.tokenName,
       symbol: tokenDefinition.symbol,
       decimals: tokenDefinition.decimals,
       initialSupply: tokenDefinition.initialSupply,

--- a/src/plugins/token/commands/create-nft-from-file/handler.ts
+++ b/src/plugins/token/commands/create-nft-from-file/handler.ts
@@ -119,7 +119,7 @@ export class TokenCreateNftFromFileCommand extends BaseTransactionCommand<
       filename: validArgs.file,
       keyManager,
       alias: tokenDefinition.name,
-      name: tokenDefinition.name,
+      name: tokenDefinition.tokenName,
       symbol: tokenDefinition.symbol,
       supplyType: tokenDefinition.supplyType.toUpperCase() as SupplyType,
       maxSupply: tokenDefinition.maxSupply,

--- a/src/plugins/token/schema.ts
+++ b/src/plugins/token/schema.ts
@@ -15,6 +15,7 @@ import {
   KeyThresholdOptionalSchema,
   MemoSchema,
   NonNegativeNumberOrBigintSchema,
+  TokenAliasNameSchema,
   TokenNameSchema,
   TokenSymbolSchema,
   TokenTypeSchema,
@@ -191,7 +192,8 @@ export function safeParseTokenData(data: unknown) {
 
 export const FungibleTokenFileSchema = z
   .object({
-    name: TokenNameSchema,
+    name: TokenAliasNameSchema.describe('CLI alias for the token'),
+    tokenName: TokenNameSchema.describe('On-chain token name'),
     symbol: TokenSymbolSchema,
     decimals: HtsDecimalsSchema,
     supplyType: z.union([z.literal('finite'), z.literal('infinite')]),
@@ -276,7 +278,8 @@ const OptionalKeyOrListSchema = z.preprocess((val) => {
 
 export const NonFungibleTokenFileSchema = z
   .object({
-    name: TokenNameSchema,
+    name: TokenAliasNameSchema.describe('CLI alias for the token'),
+    tokenName: TokenNameSchema.describe('On-chain token name'),
     symbol: TokenSymbolSchema,
     supplyType: z.union([z.literal('finite'), z.literal('infinite')]),
     maxSupply: NonNegativeNumberOrBigintSchema.optional(),


### PR DESCRIPTION
## Description

This pull request changes the following:

- Split the dual-purpose `name` field in `FungibleTokenFileSchema` and `NonFungibleTokenFileSchema` into two separate fields:
  - `name` — CLI alias (local identifier, uses `TokenAliasNameSchema`)
  - `tokenName` — on-chain token name submitted to Hedera (uses `TokenNameSchema`)
- Updated both `create-ft-from-file` and `create-nft-from-file` handlers to use `tokenDefinition.tokenName` for the blockchain transaction and `tokenDefinition.name` for alias registration
- Updated all example token JSON files to include the new `tokenName` field
- Updated unit test fixtures and schema tests to reflect the new fields — all 82 affected tests pass

### Related Issues

- Closes #1783
