### PR TITLE
feat(1692): remove redundant state, logger and config from CommandHandlerArgs

### DIFF
--- a/src/__tests__/integration/account/create-account.integration.test.ts
+++ b/src/__tests__/integration/account/create-account.integration.test.ts
@@ -33,9 +33,6 @@ describe('Create Account Integration Tests', () => {
       const createAccountResult = await accountCreate({
         args: createAccountArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
 
       const createAccountOutput =
@@ -52,9 +49,6 @@ describe('Create Account Integration Tests', () => {
       const viewAccountResult = await accountView({
         args: viewAccountArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const viewAccountOutput = viewAccountResult.result as AccountViewOutput;
       expect(viewAccountOutput.accountId).toBe(createAccountOutput.accountId);

--- a/src/__tests__/integration/account/delete-account.integration.test.ts
+++ b/src/__tests__/integration/account/delete-account.integration.test.ts
@@ -60,9 +60,6 @@ describe('Delete Account Integration Tests', () => {
       const importAccountResult = await accountImport({
         args: importAccountArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
 
       const importAccountOutput =
@@ -76,9 +73,6 @@ describe('Delete Account Integration Tests', () => {
       const deleteAccountResult = await accountDelete({
         args: deleteAccountArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const deleteAccountOutput =
         deleteAccountResult.result as AccountDeleteOutput;
@@ -90,9 +84,6 @@ describe('Delete Account Integration Tests', () => {
         accountView({
           args: { account: 'account-state-only-delete' },
           api: coreApi,
-          state: coreApi.state,
-          logger: coreApi.logger,
-          config: coreApi.config,
         }),
       ).rejects.toThrow(
         'Account not found with ID or alias: account-state-only-delete',
@@ -101,9 +92,6 @@ describe('Delete Account Integration Tests', () => {
       const viewById = await accountView({
         args: { account: accountId },
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const viewByIdOutput = viewById.result as AccountViewOutput;
       expect(viewByIdOutput.accountId).toBe(accountId);
@@ -123,9 +111,6 @@ describe('Delete Account Integration Tests', () => {
             'auto-associations': 10,
           },
           api: coreApi,
-          state: coreApi.state,
-          logger: coreApi.logger,
-          config: coreApi.config,
         });
         const victimAccountId = (
           createVictimResult.result as AccountCreateOutput
@@ -139,9 +124,6 @@ describe('Delete Account Integration Tests', () => {
             'auto-associations': 10,
           },
           api: coreApi,
-          state: coreApi.state,
-          logger: coreApi.logger,
-          config: coreApi.config,
         });
         const beneficiaryAccountId = (
           createBeneficiaryResult.result as AccountCreateOutput
@@ -156,9 +138,6 @@ describe('Delete Account Integration Tests', () => {
             'hbar-only': true,
           },
           api: coreApi,
-          state: coreApi.state,
-          logger: coreApi.logger,
-          config: coreApi.config,
         });
         const beneficiaryBefore = tinybarsFromBalanceResult(
           balanceBeneficiaryBeforeResult.result as AccountBalanceOutput,
@@ -170,9 +149,6 @@ describe('Delete Account Integration Tests', () => {
             transferId: beneficiaryAccountId,
           },
           api: coreApi,
-          state: coreApi.state,
-          logger: coreApi.logger,
-          config: coreApi.config,
         });
 
         const deleteAccountOutput =
@@ -192,9 +168,6 @@ describe('Delete Account Integration Tests', () => {
             'hbar-only': true,
           },
           api: coreApi,
-          state: coreApi.state,
-          logger: coreApi.logger,
-          config: coreApi.config,
         });
         const beneficiaryAfter = tinybarsFromBalanceResult(
           balanceBeneficiaryAfterResult.result as AccountBalanceOutput,
@@ -206,9 +179,6 @@ describe('Delete Account Integration Tests', () => {
           accountView({
             args: { account: 'account-network-delete' },
             api: coreApi,
-            state: coreApi.state,
-            logger: coreApi.logger,
-            config: coreApi.config,
           }),
         ).rejects.toThrow();
       },

--- a/src/__tests__/integration/account/import-account.integration.test.ts
+++ b/src/__tests__/integration/account/import-account.integration.test.ts
@@ -43,9 +43,6 @@ describe('Import Account Integration Tests', () => {
       const importAccountResult = await accountImport({
         args: importAccountArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
 
       const importAccountOutput =
@@ -62,9 +59,6 @@ describe('Import Account Integration Tests', () => {
       const viewAccountResult = await accountView({
         args: viewAccountArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const viewAccountOutput = viewAccountResult.result as AccountViewOutput;
       expect(viewAccountOutput.accountId).toBe(importAccountOutput.accountId);

--- a/src/__tests__/integration/config/config.integration.test.ts
+++ b/src/__tests__/integration/config/config.integration.test.ts
@@ -25,9 +25,6 @@ describe('Config Integration Tests', () => {
     const listConfigResult = await configList({
       args: {},
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const listConfigOutput = listConfigResult.result as ConfigListOutput;
@@ -50,9 +47,6 @@ describe('Config Integration Tests', () => {
     const setConfigResult = await configSet({
       args: setConfigArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const setConfigOutput = setConfigResult.result as ConfigSetOutput;
     expect(setConfigOutput.previousValue).toBe(false);
@@ -64,9 +58,6 @@ describe('Config Integration Tests', () => {
     const getConfigResult = await configGet({
       args: getConfigArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const getConfigOutput = getConfigResult.result as ConfigGetOutput;
     expect(getConfigOutput.name).toBe(ConfigOptionKey.ed25519_support_enabled);

--- a/src/__tests__/integration/credentials/credentials.integration.test.ts
+++ b/src/__tests__/integration/credentials/credentials.integration.test.ts
@@ -33,9 +33,6 @@ describe('Credentials Integration Tests', () => {
     const listResult = await credentialsList({
       args: {},
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const listOutput = listResult.result as CredentialsListOutput;
     const credentialNames = listOutput.credentials.map((c) => c.keyRefId);
@@ -44,9 +41,6 @@ describe('Credentials Integration Tests', () => {
     const removeResult = await credentialsRemove({
       args: { id: 'test-key' },
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const removeOutput = removeResult.result as CredentialsRemoveOutput;
     expect(removeOutput.keyRefId).toBe('test-key');
@@ -55,9 +49,6 @@ describe('Credentials Integration Tests', () => {
     const listAfterResult = await credentialsList({
       args: {},
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const listAfterOutput = listAfterResult.result as CredentialsListOutput;
     const credentialNamesAfterRemoval = listAfterOutput.credentials.map(

--- a/src/__tests__/integration/hbar/hbar-transfer.integration.test.ts
+++ b/src/__tests__/integration/hbar/hbar-transfer.integration.test.ts
@@ -35,9 +35,6 @@ describe('HBAR Transfer Account Integration Tests', () => {
     const createAccountResult = await accountCreate({
       args: createAccountArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const createAccountOutput =
@@ -56,9 +53,6 @@ describe('HBAR Transfer Account Integration Tests', () => {
     const transferHbarResult = await hbarTransfer({
       args: transferAccountArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const transferHbarOutput = transferHbarResult.result as HbarTransferOutput;
     expect(transferHbarOutput.status).toBe('success');
@@ -76,9 +70,6 @@ describe('HBAR Transfer Account Integration Tests', () => {
     const viewAccountResult = await accountView({
       args: viewAccountArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const viewAccountOutput = viewAccountResult.result as AccountViewOutput;
     expect(viewAccountOutput.accountId).toBe(createAccountOutput.accountId);
@@ -100,9 +91,6 @@ describe('HBAR Transfer Account Integration Tests', () => {
     const accountFromResult = await accountCreate({
       args: accountFromArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const accountFromOutput = accountFromResult.result as AccountCreateOutput;
@@ -119,9 +107,6 @@ describe('HBAR Transfer Account Integration Tests', () => {
     const accountToResult = await accountCreate({
       args: accountToArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const accountToOutput = accountToResult.result as AccountCreateOutput;
@@ -139,9 +124,6 @@ describe('HBAR Transfer Account Integration Tests', () => {
     const transferHbarResult = await hbarTransfer({
       args: transferAccountArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const transferHbarOutput = transferHbarResult.result as HbarTransferOutput;
     expect(transferHbarOutput.status).toBe('success');
@@ -158,9 +140,6 @@ describe('HBAR Transfer Account Integration Tests', () => {
     const viewAccountFromResult = await accountView({
       args: viewAccountFromArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const viewAccountFromOutput =
       viewAccountFromResult.result as AccountViewOutput;
@@ -173,9 +152,6 @@ describe('HBAR Transfer Account Integration Tests', () => {
     const viewAccountToResult = await accountView({
       args: viewAccountToArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const viewAccountToOutput = viewAccountToResult.result as AccountViewOutput;
     expect(viewAccountToOutput.accountId).toBe(accountToOutput.accountId);

--- a/src/__tests__/integration/plugin-management/plugin.integration.test.ts
+++ b/src/__tests__/integration/plugin-management/plugin.integration.test.ts
@@ -37,9 +37,6 @@ describe('Plugin Management Integration Tests', () => {
     const addPluginResult = await pluginManagementAdd({
       args: addPluginArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const addPluginOutput = addPluginResult.result as PluginManagementAddOutput;
@@ -56,9 +53,6 @@ describe('Plugin Management Integration Tests', () => {
     const viewPluginResult = await pluginManagementInfo({
       args: viewPluginArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const viewPluginOutput =
       viewPluginResult.result as PluginManagementInfoOutput;
@@ -79,9 +73,6 @@ describe('Plugin Management Integration Tests', () => {
     const disablePluginResult = await pluginManagementDisable({
       args: disablePluginArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const disablePluginOutput =
       disablePluginResult.result as PluginManagementDisableOutput;
@@ -94,9 +85,6 @@ describe('Plugin Management Integration Tests', () => {
     const listPluginResult = await pluginManagementList({
       args: {},
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const listPluginOutput =
       listPluginResult.result as PluginManagementListOutput;
@@ -112,9 +100,6 @@ describe('Plugin Management Integration Tests', () => {
     const enablePluginResult = await pluginManagementEnable({
       args: enablePluginArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const enablePluginOutput =
       enablePluginResult.result as PluginManagementEnableOutput;
@@ -128,9 +113,6 @@ describe('Plugin Management Integration Tests', () => {
     const viewPluginEnabledResult = await pluginManagementInfo({
       args: viewPluginEnabledArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const viewPluginEnabledOutput =
       viewPluginEnabledResult.result as PluginManagementInfoOutput;
@@ -153,9 +135,6 @@ describe('Plugin Management Integration Tests', () => {
     const removePluginResult = await pluginManagementRemove({
       args: removePluginArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const removePluginOutput =
       removePluginResult.result as PluginManagementRemoveOutput;
@@ -173,9 +152,6 @@ describe('Plugin Management Integration Tests', () => {
     const addPluginResult = await pluginManagementAdd({
       args: addPluginArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const addOutput = addPluginResult.result as PluginManagementAddOutput;
     expect(addOutput.added).toBe(true);
@@ -183,9 +159,6 @@ describe('Plugin Management Integration Tests', () => {
     const listBeforeReset = await pluginManagementList({
       args: {},
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const listBeforeOutput =
       listBeforeReset.result as PluginManagementListOutput;
@@ -194,9 +167,6 @@ describe('Plugin Management Integration Tests', () => {
     const resetResult = await pluginManagementReset({
       args: {},
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const resetOutput = resetResult.result as PluginManagementResetOutput;
     expect(resetOutput.reset).toBe(true);
@@ -207,9 +177,6 @@ describe('Plugin Management Integration Tests', () => {
     const listAfterReset = await pluginManagementList({
       args: {},
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const listAfterOutput = listAfterReset.result as PluginManagementListOutput;
     expect(listAfterOutput.plugins.some((p) => p.name === 'test')).toBe(false);

--- a/src/__tests__/integration/token/create-nft.integration.test.ts
+++ b/src/__tests__/integration/token/create-nft.integration.test.ts
@@ -34,9 +34,6 @@ describe('Create NFT Integration Tests', () => {
     const createAccountResult = await accountCreate({
       args: createAccountArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const createAccountOutput =
@@ -53,9 +50,6 @@ describe('Create NFT Integration Tests', () => {
     const viewAccountResult = await accountView({
       args: viewAccountArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const viewAccountOutput = viewAccountResult.result as AccountViewOutput;
     expect(viewAccountOutput.accountId).toBe(createAccountOutput.accountId);
@@ -76,9 +70,6 @@ describe('Create NFT Integration Tests', () => {
     const createNftResult = await tokenCreateNft({
       args: createNftArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const createNftOutput = createNftResult.result as TokenCreateNftOutput;
     expect(createNftOutput.network).toBe(network);

--- a/src/__tests__/integration/token/create-token.integration.test.ts
+++ b/src/__tests__/integration/token/create-token.integration.test.ts
@@ -35,9 +35,6 @@ describe('Create Token Integration Tests', () => {
     const createAccountResult = await accountCreate({
       args: createAccountArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const createAccountOutput =
@@ -54,9 +51,6 @@ describe('Create Token Integration Tests', () => {
     const viewAccountResult = await accountView({
       args: viewAccountArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const viewAccountOutput = viewAccountResult.result as AccountViewOutput;
     expect(viewAccountOutput.accountId).toBe(createAccountOutput.accountId);
@@ -77,9 +71,6 @@ describe('Create Token Integration Tests', () => {
     const createTokenResult = await tokenCreateFt({
       args: createTokenArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const createTokenOutput = createTokenResult.result as TokenCreateFtOutput;
     expect(createTokenOutput.network).toBe(network);
@@ -101,9 +92,6 @@ describe('Create Token Integration Tests', () => {
     const accountBalanceResult = await accountBalance({
       args: accountBalanceArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const accountBalanceOutput =
       accountBalanceResult.result as AccountBalanceOutput;

--- a/src/__tests__/integration/token/custom-fees.integration.test.ts
+++ b/src/__tests__/integration/token/custom-fees.integration.test.ts
@@ -64,9 +64,6 @@ describe('Token Custom Fees Integration Tests', () => {
     const result = await tokenCreateFtFromFile({
       args: { file: filePath },
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const output = result.result as TokenCreateFtFromFileOutput;
@@ -113,9 +110,6 @@ describe('Token Custom Fees Integration Tests', () => {
     const result = await tokenCreateFtFromFile({
       args: { file: filePath },
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const output = result.result as TokenCreateFtFromFileOutput;
@@ -159,9 +153,6 @@ describe('Token Custom Fees Integration Tests', () => {
     const result = await tokenCreateFtFromFile({
       args: { file: filePath },
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const output = result.result as TokenCreateFtFromFileOutput;

--- a/src/__tests__/integration/token/import-token.integration.test.ts
+++ b/src/__tests__/integration/token/import-token.integration.test.ts
@@ -42,9 +42,6 @@ describe('Import Token Integration Tests', () => {
     const createTokenResult = await tokenCreateFt({
       args: createTokenArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const createTokenOutput = createTokenResult.result as TokenCreateFtOutput;
@@ -61,9 +58,6 @@ describe('Import Token Integration Tests', () => {
     await tokenDelete({
       args: { token: tokenId, stateOnly: true },
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
   });
 
@@ -71,9 +65,6 @@ describe('Import Token Integration Tests', () => {
     await tokenDelete({
       args: { token: tokenId },
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
   });
 
@@ -84,9 +75,6 @@ describe('Import Token Integration Tests', () => {
     const importTokenResult = await tokenImport({
       args: importTokenArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const importTokenOutput = importTokenResult.result as TokenImportOutput;
@@ -99,9 +87,6 @@ describe('Import Token Integration Tests', () => {
     const listTokenResult = await tokenList({
       args: listTokenArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const listTokenOutput = listTokenResult.result as TokenListOutput;
     const token = listTokenOutput.tokens.find((t) => t.tokenId === tokenId);
@@ -119,9 +104,6 @@ describe('Import Token Integration Tests', () => {
     const importTokenResult = await tokenImport({
       args: importTokenArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const importTokenOutput = importTokenResult.result as TokenImportOutput;
@@ -134,9 +116,6 @@ describe('Import Token Integration Tests', () => {
     const listTokenResult = await tokenList({
       args: listTokenArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const listTokenOutput = listTokenResult.result as TokenListOutput;
     const token = listTokenOutput.tokens.find((t) => t.tokenId === tokenId);

--- a/src/__tests__/integration/token/list-token.integration.test.ts
+++ b/src/__tests__/integration/token/list-token.integration.test.ts
@@ -31,9 +31,6 @@ describe('List Token Integration Tests', () => {
     const createTokenResult = await tokenCreateFt({
       args: createTokenArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const createTokenOutput = createTokenResult.result as TokenCreateFtOutput;
     expect(createTokenOutput.network).toBe(network);
@@ -51,9 +48,6 @@ describe('List Token Integration Tests', () => {
     const listTokenResult = await tokenList({
       args: listTokenArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const listTokenOutput = listTokenResult.result as TokenListOutput;
     const tokenNames = listTokenOutput.tokens.map((token) => token.tokenId);

--- a/src/__tests__/integration/token/mint-ft.integration.test.ts
+++ b/src/__tests__/integration/token/mint-ft.integration.test.ts
@@ -37,9 +37,6 @@ describe('Mint FT Integration Tests', () => {
     const createAccountResult = await accountCreate({
       args: createAccountArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const createAccountOutput =
@@ -56,9 +53,6 @@ describe('Mint FT Integration Tests', () => {
     const viewAccountResult = await accountView({
       args: viewAccountArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const viewAccountOutput = viewAccountResult.result as AccountViewOutput;
     expect(viewAccountOutput.accountId).toBe(createAccountOutput.accountId);
@@ -78,9 +72,6 @@ describe('Mint FT Integration Tests', () => {
     const createTokenResult = await tokenCreateFt({
       args: createTokenArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const createTokenOutput = createTokenResult.result as TokenCreateFtOutput;
     expect(createTokenOutput.network).toBe(network);
@@ -102,9 +93,6 @@ describe('Mint FT Integration Tests', () => {
         accountBalance({
           args: accountBalanceBeforeMintArgs,
           api: coreApi,
-          state: coreApi.state,
-          logger: coreApi.logger,
-          config: coreApi.config,
         }).then((r) => r.result as AccountBalanceOutput),
       (output) => (output.tokenBalances?.length ?? 0) > 0,
     );
@@ -126,9 +114,6 @@ describe('Mint FT Integration Tests', () => {
     const mintFtResult = await tokenMintFt({
       args: mintFtArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const mintFtOutput = mintFtResult.result as TokenMintFtOutput;
     expect(mintFtOutput.tokenId).toBe(createTokenOutput.tokenId);
@@ -146,9 +131,6 @@ describe('Mint FT Integration Tests', () => {
         accountBalance({
           args: accountBalanceAfterMintArgs,
           api: coreApi,
-          state: coreApi.state,
-          logger: coreApi.logger,
-          config: coreApi.config,
         }).then((r) => r.result as AccountBalanceOutput),
       (output) => output.tokenBalances?.at(0)?.balance === 150n,
     );

--- a/src/__tests__/integration/token/mint-nft.integration.test.ts
+++ b/src/__tests__/integration/token/mint-nft.integration.test.ts
@@ -37,9 +37,6 @@ describe('Mint NFT Integration Tests', () => {
     const createAccountResult = await accountCreate({
       args: createAccountArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const createAccountOutput =
@@ -56,9 +53,6 @@ describe('Mint NFT Integration Tests', () => {
     const viewAccountResult = await accountView({
       args: viewAccountArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const viewAccountOutput = viewAccountResult.result as AccountViewOutput;
     expect(viewAccountOutput.accountId).toBe(createAccountOutput.accountId);
@@ -79,9 +73,6 @@ describe('Mint NFT Integration Tests', () => {
     const createNftResult = await tokenCreateNft({
       args: createNftArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const createNftOutput = createNftResult.result as TokenCreateNftOutput;
     expect(createNftOutput.network).toBe(network);
@@ -101,9 +92,6 @@ describe('Mint NFT Integration Tests', () => {
     const mintNftResult = await tokenMintNft({
       args: mintNftArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const mintNftOutput = mintNftResult.result as TokenMintNftOutput;
     expect(mintNftOutput.tokenId).toBe(createNftOutput.tokenId);
@@ -120,9 +108,6 @@ describe('Mint NFT Integration Tests', () => {
     const viewTokenResult = await tokenView({
       args: viewTokenArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const viewTokenOutput = viewTokenResult.result as TokenViewOutput;
     expect(viewTokenOutput.tokenId).toBe(createNftOutput.tokenId);

--- a/src/__tests__/integration/token/transfer-nft.integration.test.ts
+++ b/src/__tests__/integration/token/transfer-nft.integration.test.ts
@@ -45,9 +45,6 @@ describe('Transfer NFT Integration Tests', () => {
       const createSourceAccountResult = await accountCreate({
         args: createSourceAccountArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
 
       const createSourceAccountOutput =
@@ -69,9 +66,6 @@ describe('Transfer NFT Integration Tests', () => {
       const createDestinationAccountResult = await accountCreate({
         args: createDestinationAccountArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
 
       const createDestinationAccountOutput =
@@ -97,9 +91,6 @@ describe('Transfer NFT Integration Tests', () => {
       const createNftResult = await tokenCreateNft({
         args: createNftArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const createNftOutput = createNftResult.result as TokenCreateNftOutput;
       expect(createNftOutput.network).toBe(network);
@@ -121,9 +112,6 @@ describe('Transfer NFT Integration Tests', () => {
       const mintNftResult = await tokenMintNft({
         args: mintNftArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const mintNftOutput = mintNftResult.result as TokenMintNftOutput;
       expect(mintNftOutput.tokenId).toBe(createNftOutput.tokenId);
@@ -140,9 +128,6 @@ describe('Transfer NFT Integration Tests', () => {
       const associateTokenResult = await tokenAssociate({
         args: associateTokenArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const associateTokenOutput =
         associateTokenResult.result as TokenAssociateOutput;
@@ -160,9 +145,6 @@ describe('Transfer NFT Integration Tests', () => {
       const viewTokenBeforeTransferResult = await tokenView({
         args: viewTokenBeforeTransferArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const viewTokenBeforeTransferOutput =
         viewTokenBeforeTransferResult.result as TokenViewOutput;
@@ -188,9 +170,6 @@ describe('Transfer NFT Integration Tests', () => {
       const transferNftResult = await tokenTransferNft({
         args: transferNftArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const transferNftOutput =
         transferNftResult.result as TokenTransferNftOutput;
@@ -214,9 +193,6 @@ describe('Transfer NFT Integration Tests', () => {
       const viewTokenAfterTransferResult = await tokenView({
         args: viewTokenAfterTransferArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const viewTokenAfterTransferOutput =
         viewTokenAfterTransferResult.result as TokenViewOutput;
@@ -246,9 +222,6 @@ describe('Transfer NFT Integration Tests', () => {
       const createAccountResult = await accountCreate({
         args: createAccountArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
 
       const createAccountOutput =
@@ -272,9 +245,6 @@ describe('Transfer NFT Integration Tests', () => {
       const createNftResult = await tokenCreateNft({
         args: createNftArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const createNftOutput = createNftResult.result as TokenCreateNftOutput;
 
@@ -288,9 +258,6 @@ describe('Transfer NFT Integration Tests', () => {
       const mintNftResult = await tokenMintNft({
         args: mintNftArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const mintNftOutput = mintNftResult.result as TokenMintNftOutput;
 
@@ -305,9 +272,6 @@ describe('Transfer NFT Integration Tests', () => {
       await accountCreate({
         args: createAnotherAccountArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
 
       await delay(5000);
@@ -322,9 +286,6 @@ describe('Transfer NFT Integration Tests', () => {
         tokenTransferNft({
           args: transferNftArgs,
           api: coreApi,
-          state: coreApi.state,
-          logger: coreApi.logger,
-          config: coreApi.config,
         }),
       ).rejects.toThrow('NFT not owned by sender');
     }, 90000);
@@ -341,9 +302,6 @@ describe('Transfer NFT Integration Tests', () => {
         tokenTransferNft({
           args: transferNftArgs,
           api: coreApi,
-          state: coreApi.state,
-          logger: coreApi.logger,
-          config: coreApi.config,
         }),
       ).rejects.toThrow();
     });

--- a/src/__tests__/integration/token/transfer-token.integration.test.ts
+++ b/src/__tests__/integration/token/transfer-token.integration.test.ts
@@ -42,9 +42,6 @@ describe('Transfer Token Integration Tests', () => {
     const createAccountResult = await accountCreate({
       args: createAccountArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const createAccountOutput =
@@ -61,9 +58,6 @@ describe('Transfer Token Integration Tests', () => {
     const viewAccountResult = await accountView({
       args: viewAccountArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const viewAccountOutput = viewAccountResult.result as AccountViewOutput;
     expect(viewAccountOutput.accountId).toBe(createAccountOutput.accountId);
@@ -81,9 +75,6 @@ describe('Transfer Token Integration Tests', () => {
     const createTokenResult = await tokenCreateFt({
       args: createTokenArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const createTokenOutput = createTokenResult.result as TokenCreateFtOutput;
     expect(createTokenOutput.network).toBe(network);
@@ -104,9 +95,6 @@ describe('Transfer Token Integration Tests', () => {
     const associateTokenResult = await tokenAssociate({
       args: associateTokenArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const associateTokenOutput =
       associateTokenResult.result as TokenAssociateOutput;
@@ -124,9 +112,6 @@ describe('Transfer Token Integration Tests', () => {
     const transferTokenResult = await tokenTransferFt({
       args: transferTokenArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const transferTokenOutput =
       transferTokenResult.result as TokenTransferFtOutput;
@@ -145,9 +130,6 @@ describe('Transfer Token Integration Tests', () => {
     const accountBalanceResult = await accountBalance({
       args: accountBalanceArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const accountBalanceOutput =
       accountBalanceResult.result as AccountBalanceOutput;

--- a/src/__tests__/integration/topic/create-topic.integration.test.ts
+++ b/src/__tests__/integration/topic/create-topic.integration.test.ts
@@ -29,9 +29,6 @@ describe('Create Topic Integration Tests', () => {
     const createTopicResult = await topicCreate({
       args: createTopicArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const createTopicOutput = createTopicResult.result as TopicCreateOutput;
@@ -47,9 +44,6 @@ describe('Create Topic Integration Tests', () => {
     const listTopicResult = await topicList({
       args: listTopicArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const listTopicOutput = listTopicResult.result as TopicListOutput;
     const topic = listTopicOutput.topics.find(

--- a/src/__tests__/integration/topic/delete-topic.integration.test.ts
+++ b/src/__tests__/integration/topic/delete-topic.integration.test.ts
@@ -30,9 +30,6 @@ describe('Delete Topic Integration Tests', () => {
       const createTopicResult = await topicCreate({
         args: createTopicArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
 
       const createTopicOutput = createTopicResult.result as TopicCreateOutput;
@@ -45,9 +42,6 @@ describe('Delete Topic Integration Tests', () => {
       const listTopicResult = await topicList({
         args: listTopicArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const listTopicOutput = listTopicResult.result as TopicListOutput;
       const topicBeforeDelete = listTopicOutput.topics.find(
@@ -63,9 +57,6 @@ describe('Delete Topic Integration Tests', () => {
       const deleteTopicResult = await topicDelete({
         args: deleteTopicArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const deleteTopicOutput = deleteTopicResult.result as TopicDeleteOutput;
       expect(deleteTopicOutput.deletedTopic.name).toBe('topic-to-be-deleted');
@@ -77,9 +68,6 @@ describe('Delete Topic Integration Tests', () => {
       const listAfterDeleteResult = await topicList({
         args: listTopicArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const listAfterDeleteOutput =
         listAfterDeleteResult.result as TopicListOutput;
@@ -96,9 +84,6 @@ describe('Delete Topic Integration Tests', () => {
       const createTopicResult = await topicCreate({
         args: createTopicArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
 
       const createTopicOutput = createTopicResult.result as TopicCreateOutput;
@@ -111,9 +96,6 @@ describe('Delete Topic Integration Tests', () => {
       const deleteTopicResult = await topicDelete({
         args: deleteTopicArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const deleteTopicOutput = deleteTopicResult.result as TopicDeleteOutput;
       expect(deleteTopicOutput.deletedTopic.topicId).toBe(
@@ -127,9 +109,6 @@ describe('Delete Topic Integration Tests', () => {
       const listAfterDeleteResult = await topicList({
         args: listTopicArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const listAfterDeleteOutput =
         listAfterDeleteResult.result as TopicListOutput;
@@ -149,9 +128,6 @@ describe('Delete Topic Integration Tests', () => {
             stateOnly: true,
           },
           api: coreApi,
-          state: coreApi.state,
-          logger: coreApi.logger,
-          config: coreApi.config,
         }),
       ).rejects.toThrow(NotFoundError);
     });
@@ -166,9 +142,6 @@ describe('Delete Topic Integration Tests', () => {
             ],
           },
           api: coreApi,
-          state: coreApi.state,
-          logger: coreApi.logger,
-          config: coreApi.config,
         }),
       ).rejects.toThrow(`Topic ${MOCK_NONEXISTENT_ENTITY_ID} not found`);
     });

--- a/src/__tests__/integration/topic/import-topic.integration.test.ts
+++ b/src/__tests__/integration/topic/import-topic.integration.test.ts
@@ -43,9 +43,6 @@ describeSuite('Import Topic Integration Tests', () => {
     const createTopicResult = await topicCreate({
       args: createTopicArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const createTopicOutput = createTopicResult.result as TopicCreateOutput;
@@ -58,9 +55,6 @@ describeSuite('Import Topic Integration Tests', () => {
     await topicDelete({
       args: deleteTopicArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     await delay(5000);
@@ -74,9 +68,6 @@ describeSuite('Import Topic Integration Tests', () => {
     await topicDelete({
       args: deleteTopicArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
   });
 
@@ -87,9 +78,6 @@ describeSuite('Import Topic Integration Tests', () => {
     const importTopicResult = await topicImport({
       args: importTopicArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const importTopicOutput = importTopicResult.result as TopicImportOutput;
@@ -102,9 +90,6 @@ describeSuite('Import Topic Integration Tests', () => {
     const listTopicResult = await topicList({
       args: listTopicArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const listTopicOutput = listTopicResult.result as TopicListOutput;
     const topic = listTopicOutput.topics.find((t) => t.topicId === topicId);
@@ -127,9 +112,6 @@ describeSuite('Import Topic Integration Tests', () => {
     const importTopicResult = await topicImport({
       args: importTopicArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const importTopicOutput = importTopicResult.result as TopicImportOutput;
@@ -143,9 +125,6 @@ describeSuite('Import Topic Integration Tests', () => {
     const listTopicResult = await topicList({
       args: listTopicArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const listTopicOutput = listTopicResult.result as TopicListOutput;
     const topic = listTopicOutput.topics.find((t) => t.topicId === topicId);

--- a/src/__tests__/integration/topic/topic-messages.integration.test.ts
+++ b/src/__tests__/integration/topic/topic-messages.integration.test.ts
@@ -41,9 +41,6 @@ describeSuite('Topic Messages Integration Tests', () => {
     const createTopicResult = await topicCreate({
       args: createTopicArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
 
     const createTopicOutput = createTopicResult.result as TopicCreateOutput;
@@ -58,9 +55,6 @@ describeSuite('Topic Messages Integration Tests', () => {
     const listTopicResult = await topicList({
       args: listTopicArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const listTopicOutput = listTopicResult.result as TopicListOutput;
     const topic = listTopicOutput.topics.find(
@@ -84,9 +78,6 @@ describeSuite('Topic Messages Integration Tests', () => {
       const submitMessageResult = await topicSubmitMessage({
         args: topicMessageSubmitArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
       const submitMessageOutput =
         submitMessageResult.result as TopicSubmitMessageOutput;
@@ -103,9 +94,6 @@ describeSuite('Topic Messages Integration Tests', () => {
     const findMessageEqResult = await topicFindMessage({
       args: findMessageEqArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const findMessageEqOutput =
       findMessageEqResult.result as TopicFindMessageOutput;
@@ -119,9 +107,6 @@ describeSuite('Topic Messages Integration Tests', () => {
     const findMessageGtResult = await topicFindMessage({
       args: findMessageGtArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const findMessageGtOutput =
       findMessageGtResult.result as TopicFindMessageOutput;
@@ -135,9 +120,6 @@ describeSuite('Topic Messages Integration Tests', () => {
     const findMessageGteResult = await topicFindMessage({
       args: findMessageGteArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const findMessageGteOutput =
       findMessageGteResult.result as TopicFindMessageOutput;
@@ -151,9 +133,6 @@ describeSuite('Topic Messages Integration Tests', () => {
     const findMessageLtResult = await topicFindMessage({
       args: findMessageLtArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const findMessageLtOutput =
       findMessageLtResult.result as TopicFindMessageOutput;
@@ -167,9 +146,6 @@ describeSuite('Topic Messages Integration Tests', () => {
     const findMessageLteResult = await topicFindMessage({
       args: findMessageLteArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const findMessageLteOutput =
       findMessageLteResult.result as TopicFindMessageOutput;

--- a/src/__tests__/mocks/mocks.ts
+++ b/src/__tests__/mocks/mocks.ts
@@ -643,23 +643,6 @@ export const makeArgs = (
 
   return {
     api: apiObject,
-    logger,
-    state: {
-      list: jest.fn().mockReturnValue([]),
-      get: jest.fn(),
-      set: jest.fn(),
-      delete: jest.fn(),
-      clear: jest.fn(),
-      has: jest.fn(),
-      getNamespaces: jest.fn(),
-      getKeys: jest.fn(),
-      subscribe: jest.fn(),
-      getActions: jest.fn(),
-      getState: jest.fn(),
-      getStorageDirectory: jest.fn().mockReturnValue(''),
-      isInitialized: jest.fn().mockReturnValue(true),
-    } as unknown as StateService,
-    config: makeConfigMock(),
     args,
     hooks: new Map(),
   };

--- a/src/__tests__/utils/network-and-operator-setup.ts
+++ b/src/__tests__/utils/network-and-operator-setup.ts
@@ -39,17 +39,11 @@ export const setDefaultOperatorForNetwork = async (
   await networkUse({
     args: useNetworkArgs,
     api: coreApi,
-    state: coreApi.state,
-    logger: coreApi.logger,
-    config: coreApi.config,
   });
 
   const getOperatorResult = await networkGetOperator({
     args: {},
     api: coreApi,
-    state: coreApi.state,
-    logger: coreApi.logger,
-    config: coreApi.config,
   });
   const getOperatorOutput =
     getOperatorResult.result as NetworkGetOperatorOutput;
@@ -60,9 +54,6 @@ export const setDefaultOperatorForNetwork = async (
     await networkSetOperator({
       args: setOperatorArgs,
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
   }
 };

--- a/src/__tests__/utils/teardown.ts
+++ b/src/__tests__/utils/teardown.ts
@@ -20,9 +20,6 @@ export const returnFundsFromCreatedAccountsToMainAccount = async (
     const accountListResult = await accountList({
       args: {},
       api: coreApi,
-      state: coreApi.state,
-      logger: coreApi.logger,
-      config: coreApi.config,
     });
     const accountOutput = accountListResult.result as AccountListOutput;
     const accounts = accountOutput.accounts;
@@ -35,9 +32,6 @@ export const returnFundsFromCreatedAccountsToMainAccount = async (
       await accountImport({
         args: importAccountArgs,
         api: coreApi,
-        state: coreApi.state,
-        logger: coreApi.logger,
-        config: coreApi.config,
       });
     } catch {
       // main-account may already exist
@@ -48,9 +42,6 @@ export const returnFundsFromCreatedAccountsToMainAccount = async (
         const viewAccountResult = await accountView({
           args: { account: account.name },
           api: coreApi,
-          state: coreApi.state,
-          logger: coreApi.logger,
-          config: coreApi.config,
         });
         const viewAccountOutput = viewAccountResult.result as AccountViewOutput;
         const args: Record<string, unknown> = {
@@ -61,9 +52,6 @@ export const returnFundsFromCreatedAccountsToMainAccount = async (
         await hbarTransfer({
           args,
           api: coreApi,
-          state: coreApi.state,
-          logger: coreApi.logger,
-          config: coreApi.config,
         });
       } catch {
         // skip accounts that cannot be viewed or transferred

--- a/src/core/plugins/plugin-manager.ts
+++ b/src/core/plugins/plugin-manager.ts
@@ -405,9 +405,6 @@ export class PluginManager {
         _: commandArgs,
       },
       api: this.coreApi,
-      state: this.coreApi.state,
-      config: this.coreApi.config,
-      logger: this.logger,
       hooks: phaseHooks,
     };
 

--- a/src/core/plugins/plugin.interface.ts
+++ b/src/core/plugins/plugin.interface.ts
@@ -7,16 +7,12 @@ export type * from './plugin.types';
 export interface CommandHandlerArgs {
   args: Record<string, unknown>;
   api: CoreApi; // injected instance per execution
-  state: StateManager; // namespaced access provided by Core
-  config: ConfigView;
-  logger: Logger;
   hooks?: Map<HookPhase, Hook[]>;
 }
 
 // Import types from other interfaces
 import type { CoreApi } from '@/core/core-api/core-api.interface';
 import type { ConfigService } from '@/core/services/config/config-service.interface';
-import type { Logger } from '@/core/services/logger/logger-service.interface';
 import type { StateService } from '@/core/services/state/state-service.interface';
 
 // Type aliases for ADR-001 compliance

--- a/src/plugins/account/__tests__/unit/clear.test.ts
+++ b/src/plugins/account/__tests__/unit/clear.test.ts
@@ -39,8 +39,8 @@ describe('account plugin - clear command (ADR-003)', () => {
       api: {
         state: makeStateMock(),
         alias,
+        logger,
       } as unknown as CoreApi,
-      logger,
       args: {},
     };
 
@@ -73,8 +73,8 @@ describe('account plugin - clear command (ADR-003)', () => {
       api: {
         state: makeStateMock(),
         alias,
+        logger,
       } as unknown as CoreApi,
-      logger,
       args: {},
     };
 

--- a/src/plugins/account/__tests__/unit/helpers/mocks.ts
+++ b/src/plugins/account/__tests__/unit/helpers/mocks.ts
@@ -18,13 +18,11 @@ import type { AccountData } from '@/plugins/account/schema';
 import { createMockTransaction } from '@/__tests__/mocks/hedera-sdk-mocks';
 import {
   makeAliasMock as makeGlobalAliasMock,
-  makeConfigMock,
   makeIdentityResolutionServiceMock,
   makeKeyResolverMock,
   makeKmsMock as makeGlobalKmsMock,
   makeMirrorMock as makeGlobalMirrorMock,
   makeNetworkMock as makeGlobalNetworkMock,
-  makeStateMock,
   makeTxExecuteMock,
   makeTxSignMock,
 } from '@/__tests__/mocks/mocks';
@@ -219,6 +217,7 @@ export const makeArgs = (
   args: Record<string, unknown>,
 ): CommandHandlerArgs => ({
   api: {
+    logger,
     pluginManagement: {
       listPlugins: jest.fn().mockReturnValue([]),
       getPlugin: jest.fn(),
@@ -234,9 +233,6 @@ export const makeArgs = (
     } as PluginManagementService,
     ...api,
   } as CoreApi,
-  logger,
-  state: makeStateMock(),
-  config: makeConfigMock(),
   args,
   hooks: new Map(),
 });

--- a/src/plugins/account/commands/balance/handler.ts
+++ b/src/plugins/account/commands/balance/handler.ts
@@ -18,7 +18,7 @@ import { AccountBalanceInputSchema, TokenEntityType } from './input';
 
 export class AccountBalanceCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = AccountBalanceInputSchema.parse(args.args);
 
@@ -28,7 +28,7 @@ export class AccountBalanceCommand implements Command {
     const tokenOnly = !!token;
     const raw = validArgs.raw;
 
-    logger.info(`Getting balance for account: ${accountIdOrNameOrAlias}`);
+    api.logger.info(`Getting balance for account: ${accountIdOrNameOrAlias}`);
 
     const network = api.network.getCurrentNetwork();
     let accountId = accountIdOrNameOrAlias;
@@ -40,7 +40,9 @@ export class AccountBalanceCommand implements Command {
     );
     if (account && account.entityId) {
       accountId = account.entityId;
-      logger.info(`Found account in state: ${account.alias} -> ${accountId}`);
+      api.logger.info(
+        `Found account in state: ${account.alias} -> ${accountId}`,
+      );
     } else {
       const accountIdParseResult = EntityIdSchema.safeParse(
         accountIdOrNameOrAlias,

--- a/src/plugins/account/commands/clear/handler.ts
+++ b/src/plugins/account/commands/clear/handler.ts
@@ -7,11 +7,11 @@ import { ZustandAccountStateHelper } from '@/plugins/account/zustand-state-helpe
 
 export class AccountClearCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const accountState = new ZustandAccountStateHelper(api.state, logger);
+    const accountState = new ZustandAccountStateHelper(api.state, api.logger);
 
-    logger.info('Clearing all accounts...');
+    api.logger.info('Clearing all accounts...');
 
     const accounts = accountState.listAccounts();
     const count = accounts.length;

--- a/src/plugins/account/commands/create/handler.ts
+++ b/src/plugins/account/commands/create/handler.ts
@@ -37,7 +37,7 @@ export class AccountCreateCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<CreateNormalisedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = AccountCreateInputSchema.parse(args.args);
 
@@ -67,7 +67,7 @@ export class AccountCreateCommand extends BaseTransactionCommand<
       balanceCheckAccountId,
     );
 
-    logger.info(`Creating account with name: ${alias}`);
+    api.logger.info(`Creating account with name: ${alias}`);
 
     let keyRefId: string;
     let publicKey: string;
@@ -152,7 +152,7 @@ export class AccountCreateCommand extends BaseTransactionCommand<
     _signTransactionResult: CreateSignTransactionResult,
     executeTransactionResult: CreateExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
     if (!executeTransactionResult.success) {
       throw new TransactionError(
@@ -197,7 +197,7 @@ export class AccountCreateCommand extends BaseTransactionCommand<
       normalisedParams.network,
       executeTransactionResult.accountId,
     );
-    const accountState = new ZustandAccountStateHelper(api.state, logger);
+    const accountState = new ZustandAccountStateHelper(api.state, api.logger);
     accountState.saveAccount(accountKey, accountData);
 
     const outputData: AccountCreateOutput = {

--- a/src/plugins/account/commands/delete/handler.ts
+++ b/src/plugins/account/commands/delete/handler.ts
@@ -107,8 +107,8 @@ export class AccountDeleteCommand extends BaseTransactionCommand<
     stateKey: string;
     accountRef: string;
   }> {
-    const { api, logger } = args;
-    const accountState = new ZustandAccountStateHelper(api.state, logger);
+    const { api } = args;
+    const accountState = new ZustandAccountStateHelper(api.state, api.logger);
     const { stateKey, accountRef, network } =
       await this.resolveEntityIdFromAccountRef(args);
 
@@ -139,7 +139,7 @@ export class AccountDeleteCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<DeleteNormalisedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = AccountDeleteInputSchema.parse(args.args);
     const credential = KeySchema.parse(validArgs.account);
     const keyManager = api.config.getOption<KeyManager>(
@@ -159,7 +159,7 @@ export class AccountDeleteCommand extends BaseTransactionCommand<
     }
     const network = api.network.getCurrentNetwork();
     const stateKey = composeKey(network, resolvedCredential.accountId);
-    const accountState = new ZustandAccountStateHelper(api.state, logger);
+    const accountState = new ZustandAccountStateHelper(api.state, api.logger);
     const localAccount = accountState.getAccount(stateKey);
 
     const transferAccountId = this.resolveTransferAccountId(

--- a/src/plugins/account/commands/import/handler.ts
+++ b/src/plugins/account/commands/import/handler.ts
@@ -15,9 +15,9 @@ import { AccountImportInputSchema } from './input';
 
 export class AccountImportCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const accountState = new ZustandAccountStateHelper(api.state, logger);
+    const accountState = new ZustandAccountStateHelper(api.state, api.logger);
 
     const validArgs = AccountImportInputSchema.parse(args.args);
 
@@ -46,7 +46,7 @@ export class AccountImportCommand implements Command {
 
     const accountInfo = await api.mirror.getAccountOrThrow(accountId);
 
-    logger.info(`Importing account: ${accountKey} (${accountId})`);
+    api.logger.info(`Importing account: ${accountKey} (${accountId})`);
 
     const evmAddress = buildAccountEvmAddress({
       accountId,

--- a/src/plugins/account/commands/list/handler.ts
+++ b/src/plugins/account/commands/list/handler.ts
@@ -11,15 +11,15 @@ import { AccountListInputSchema } from './input';
 
 export class AccountListCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const accountState = new ZustandAccountStateHelper(api.state, logger);
+    const accountState = new ZustandAccountStateHelper(api.state, api.logger);
 
     const validArgs = AccountListInputSchema.parse(args.args);
 
     const showPrivateKeys = validArgs.private;
 
-    logger.info('Listing all accounts...');
+    api.logger.info('Listing all accounts...');
 
     const accounts = accountState.listAccounts();
 

--- a/src/plugins/account/commands/update/handler.ts
+++ b/src/plugins/account/commands/update/handler.ts
@@ -39,12 +39,12 @@ export class AccountUpdateCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<UpdateNormalisedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = AccountUpdateInputSchema.parse(args.args);
     const network = api.network.getCurrentNetwork();
     const accountRef = validArgs.account;
-    const accountState = new ZustandAccountStateHelper(api.state, logger);
+    const accountState = new ZustandAccountStateHelper(api.state, api.logger);
 
     const isEntityId = EntityIdSchema.safeParse(accountRef).success;
     let accountStateKey: string;
@@ -191,7 +191,7 @@ export class AccountUpdateCommand extends BaseTransactionCommand<
     _signTransactionResult: UpdateSignTransactionResult,
     executeTransactionResult: UpdateExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
     if (!executeTransactionResult.success) {
       throw new TransactionError(
@@ -200,7 +200,7 @@ export class AccountUpdateCommand extends BaseTransactionCommand<
       );
     }
 
-    const accountState = new ZustandAccountStateHelper(api.state, logger);
+    const accountState = new ZustandAccountStateHelper(api.state, api.logger);
     const existingAccount = accountState.getAccount(
       normalisedParams.accountStateKey,
     );

--- a/src/plugins/account/commands/view/handler.ts
+++ b/src/plugins/account/commands/view/handler.ts
@@ -10,13 +10,13 @@ import { AccountViewInputSchema } from './input';
 
 export class AccountViewCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = AccountViewInputSchema.parse(args.args);
 
     const accountIdOrNameOrAlias = validArgs.account;
 
-    logger.info(`Viewing account details: ${accountIdOrNameOrAlias}`);
+    api.logger.info(`Viewing account details: ${accountIdOrNameOrAlias}`);
 
     let accountId = accountIdOrNameOrAlias;
 
@@ -28,7 +28,7 @@ export class AccountViewCommand implements Command {
     );
     if (account && account.entityId) {
       accountId = account.entityId;
-      logger.info(`Found account in state: ${account.alias}`);
+      api.logger.info(`Found account in state: ${account.alias}`);
     } else {
       const accountIdParseResult = EntityIdSchema.safeParse(
         accountIdOrNameOrAlias,

--- a/src/plugins/account/hooks/account-create-state/handler.ts
+++ b/src/plugins/account/hooks/account-create-state/handler.ts
@@ -35,10 +35,10 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
 
     switch (parsed.data.source) {
       case OrchestratorSource.BATCH:
-        await this.handleBatch(api, api.logger, parsed.data.batchData);
+        await this.handleBatch(api, parsed.data.batchData);
         break;
       case OrchestratorSource.SCHEDULE:
-        await this.handleSchedule(api, api.logger, parsed.data.scheduledData);
+        await this.handleSchedule(api, parsed.data.scheduledData);
         break;
       default:
         break;
@@ -47,11 +47,7 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
     return { breakFlow: false };
   }
 
-  private async handleBatch(
-    api: CoreApi,
-    logger: Logger,
-    batchData: BatchData,
-  ): Promise<void> {
+  private async handleBatch(api: CoreApi, batchData: BatchData): Promise<void> {
     if (!batchData.success) {
       return;
     }
@@ -59,24 +55,22 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
       if (item.command !== ACCOUNT_CREATE_COMMAND_NAME) {
         continue;
       }
-      await this.saveFromBatchItem(api, api.logger, item);
+      await this.saveFromBatchItem(api, item);
     }
   }
 
   private async handleSchedule(
     api: CoreApi,
-    logger: Logger,
     scheduledData: ScheduledTransactionData,
   ): Promise<void> {
     if (scheduledData.command !== ACCOUNT_CREATE_COMMAND_NAME) {
       return;
     }
-    await this.saveFromScheduled(api, api.logger, scheduledData);
+    await this.saveFromScheduled(api, scheduledData);
   }
 
   private async saveFromBatchItem(
     api: CoreApi,
-    logger: Logger,
     batchDataItem: BatchDataItem,
   ): Promise<void> {
     const normalisedParams = this.parseAccountCreateParams(
@@ -106,7 +100,7 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
       return;
     }
 
-    this.persistAccountCreate(api, api.logger, normalisedParams, {
+    this.persistAccountCreate(api, normalisedParams, {
       stateAccountId: receipt.accountId,
       consensusTimestamp: receipt.consensusTimestamp,
     });
@@ -114,7 +108,6 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
 
   private async saveFromScheduled(
     api: CoreApi,
-    logger: Logger,
     scheduledData: ScheduledTransactionData,
   ): Promise<void> {
     const normalisedParams = this.parseAccountCreateParams(
@@ -147,7 +140,7 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
       return;
     }
 
-    this.persistAccountCreate(api, api.logger, normalisedParams, {
+    this.persistAccountCreate(api, normalisedParams, {
       stateAccountId: accountId,
       consensusTimestamp: scheduledMirrorTx?.consensus_timestamp,
     });
@@ -155,7 +148,6 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
 
   private persistAccountCreate(
     api: CoreApi,
-    logger: Logger,
     normalisedParams: AccountCreateNormalisedParams,
     resolved: {
       stateAccountId: string;

--- a/src/plugins/account/hooks/account-create-state/handler.ts
+++ b/src/plugins/account/hooks/account-create-state/handler.ts
@@ -31,14 +31,14 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
       return { breakFlow: false };
     }
 
-    const { api, logger } = params.args;
+    const { api } = params.args;
 
     switch (parsed.data.source) {
       case OrchestratorSource.BATCH:
-        await this.handleBatch(api, logger, parsed.data.batchData);
+        await this.handleBatch(api, api.logger, parsed.data.batchData);
         break;
       case OrchestratorSource.SCHEDULE:
-        await this.handleSchedule(api, logger, parsed.data.scheduledData);
+        await this.handleSchedule(api, api.logger, parsed.data.scheduledData);
         break;
       default:
         break;
@@ -59,7 +59,7 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
       if (item.command !== ACCOUNT_CREATE_COMMAND_NAME) {
         continue;
       }
-      await this.saveFromBatchItem(api, logger, item);
+      await this.saveFromBatchItem(api, api.logger, item);
     }
   }
 
@@ -71,7 +71,7 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
     if (scheduledData.command !== ACCOUNT_CREATE_COMMAND_NAME) {
       return;
     }
-    await this.saveFromScheduled(api, logger, scheduledData);
+    await this.saveFromScheduled(api, api.logger, scheduledData);
   }
 
   private async saveFromBatchItem(
@@ -80,7 +80,7 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
     batchDataItem: BatchDataItem,
   ): Promise<void> {
     const normalisedParams = this.parseAccountCreateParams(
-      logger,
+      api.logger,
       batchDataItem.normalizedParams,
     );
     if (!normalisedParams) {
@@ -89,7 +89,7 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
 
     const innerTransactionId = batchDataItem.transactionId;
     if (!innerTransactionId) {
-      logger.warn(
+      api.logger.warn(
         `No transaction ID found for batch transaction ${batchDataItem.order}`,
       );
       return;
@@ -100,13 +100,13 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
     });
 
     if (!receipt.accountId) {
-      logger.warn(
+      api.logger.warn(
         'Transaction completed but did not return an account ID, skipping state save',
       );
       return;
     }
 
-    this.persistAccountCreate(api, logger, normalisedParams, {
+    this.persistAccountCreate(api, api.logger, normalisedParams, {
       stateAccountId: receipt.accountId,
       consensusTimestamp: receipt.consensusTimestamp,
     });
@@ -118,7 +118,7 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
     scheduledData: ScheduledTransactionData,
   ): Promise<void> {
     const normalisedParams = this.parseAccountCreateParams(
-      logger,
+      api.logger,
       scheduledData.normalizedParams,
     );
     if (!normalisedParams) {
@@ -127,7 +127,7 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
 
     const innerTransactionId = scheduledData.transactionId;
     if (!innerTransactionId) {
-      logger.warn(`No transaction ID found for scheduled transaction`);
+      api.logger.warn(`No transaction ID found for scheduled transaction`);
       return;
     }
 
@@ -141,13 +141,13 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
     const accountId = scheduledMirrorTx?.entity_id;
 
     if (!accountId) {
-      logger.warn(
+      api.logger.warn(
         'Could not resolve account ID from scheduled transaction record, skipping state save',
       );
       return;
     }
 
-    this.persistAccountCreate(api, logger, normalisedParams, {
+    this.persistAccountCreate(api, api.logger, normalisedParams, {
       stateAccountId: accountId,
       consensusTimestamp: scheduledMirrorTx?.consensus_timestamp,
     });
@@ -167,7 +167,7 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
 
     if (normalisedParams.alias) {
       if (api.alias.exists(normalisedParams.alias, normalisedParams.network)) {
-        logger.warn(
+        api.logger.warn(
           `Alias "${normalisedParams.alias}" already exists, skipping registration`,
         );
       } else {
@@ -194,7 +194,7 @@ export class AccountCreateStateHook implements Hook<PostOutputPreparationHookPar
       network: normalisedParams.network,
     };
     const accountKey = composeKey(normalisedParams.network, stateAccountId);
-    const accountState = new ZustandAccountStateHelper(api.state, logger);
+    const accountState = new ZustandAccountStateHelper(api.state, api.logger);
     accountState.saveAccount(accountKey, accountData);
   }
 

--- a/src/plugins/account/hooks/account-delete-state/handler.ts
+++ b/src/plugins/account/hooks/account-delete-state/handler.ts
@@ -1,4 +1,4 @@
-import type { CoreApi, Logger } from '@/core';
+import type { CoreApi } from '@/core';
 import type { Hook, HookResult } from '@/core/hooks/hook.interface';
 import type { PostOutputPreparationHookParams } from '@/core/hooks/types';
 
@@ -29,14 +29,13 @@ export class AccountDeleteStateHook implements Hook<PostOutputPreparationHookPar
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === ACCOUNT_DELETE_COMMAND_NAME,
     )) {
-      this.removeAccountAfterBatch(api, api.logger, batchDataItem);
+      this.removeAccountAfterBatch(api, batchDataItem);
     }
     return Promise.resolve({ breakFlow: false });
   }
 
   private removeAccountAfterBatch(
     api: CoreApi,
-    logger: Logger,
     batchDataItem: BatchDataItem,
   ): void {
     const parseResult = AccountDeleteNormalisedParamsSchema.safeParse(

--- a/src/plugins/account/hooks/account-delete-state/handler.ts
+++ b/src/plugins/account/hooks/account-delete-state/handler.ts
@@ -20,7 +20,7 @@ export class AccountDeleteStateHook implements Hook<PostOutputPreparationHookPar
       return Promise.resolve({ breakFlow: false });
     }
 
-    const { api, logger } = params.args;
+    const { api } = params.args;
     const batchData = parsed.data.batchData;
 
     if (!batchData.success) {
@@ -29,7 +29,7 @@ export class AccountDeleteStateHook implements Hook<PostOutputPreparationHookPar
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === ACCOUNT_DELETE_COMMAND_NAME,
     )) {
-      this.removeAccountAfterBatch(api, logger, batchDataItem);
+      this.removeAccountAfterBatch(api, api.logger, batchDataItem);
     }
     return Promise.resolve({ breakFlow: false });
   }
@@ -43,7 +43,7 @@ export class AccountDeleteStateHook implements Hook<PostOutputPreparationHookPar
       batchDataItem.normalizedParams,
     );
     if (!parseResult.success) {
-      logger.warn(
+      api.logger.warn(
         'Account delete batch state hook: normalized params did not match schema; skipping local state cleanup',
       );
       return;
@@ -51,7 +51,7 @@ export class AccountDeleteStateHook implements Hook<PostOutputPreparationHookPar
     const normalisedParams = parseResult.data;
     const accountHelper = new AccountHelper(
       api.state,
-      logger,
+      api.logger,
       api.alias,
       api.kms,
       api.network,

--- a/src/plugins/account/hooks/account-update-state/handler.ts
+++ b/src/plugins/account/hooks/account-update-state/handler.ts
@@ -29,14 +29,14 @@ export class AccountUpdateStateHook implements Hook<PostOutputPreparationHookPar
       return { breakFlow: false };
     }
 
-    const { api, logger } = params.args;
+    const { api } = params.args;
 
     switch (parsed.data.source) {
       case OrchestratorSource.BATCH:
-        this.handleBatch(api, logger, parsed.data.batchData);
+        this.handleBatch(api, api.logger, parsed.data.batchData);
         break;
       case OrchestratorSource.SCHEDULE:
-        await this.handleSchedule(api, logger, parsed.data.scheduledData);
+        await this.handleSchedule(api, api.logger, parsed.data.scheduledData);
         break;
       default:
         break;
@@ -57,7 +57,7 @@ export class AccountUpdateStateHook implements Hook<PostOutputPreparationHookPar
       if (item.command !== ACCOUNT_UPDATE_COMMAND_NAME) {
         continue;
       }
-      this.updateFromBatchItem(api, logger, item);
+      this.updateFromBatchItem(api, api.logger, item);
     }
   }
 
@@ -69,7 +69,7 @@ export class AccountUpdateStateHook implements Hook<PostOutputPreparationHookPar
     if (scheduledData.command !== ACCOUNT_UPDATE_COMMAND_NAME) {
       return;
     }
-    await this.updateFromScheduled(api, logger, scheduledData);
+    await this.updateFromScheduled(api, api.logger, scheduledData);
   }
 
   private updateFromBatchItem(
@@ -78,14 +78,14 @@ export class AccountUpdateStateHook implements Hook<PostOutputPreparationHookPar
     batchDataItem: BatchDataItem,
   ): void {
     const normalisedParams = this.parseAccountUpdateParams(
-      logger,
+      api.logger,
       batchDataItem.normalizedParams,
     );
     if (!normalisedParams) {
       return;
     }
 
-    this.persistAccountUpdate(api, logger, normalisedParams);
+    this.persistAccountUpdate(api, api.logger, normalisedParams);
   }
 
   private async updateFromScheduled(
@@ -94,7 +94,7 @@ export class AccountUpdateStateHook implements Hook<PostOutputPreparationHookPar
     scheduledData: ScheduledTransactionData,
   ): Promise<void> {
     const normalisedParams = this.parseAccountUpdateParams(
-      logger,
+      api.logger,
       scheduledData.normalizedParams ?? {},
     );
     if (!normalisedParams) {
@@ -103,7 +103,7 @@ export class AccountUpdateStateHook implements Hook<PostOutputPreparationHookPar
 
     const innerTransactionId = scheduledData.transactionId;
     if (!innerTransactionId) {
-      logger.warn(`No transaction ID found for scheduled transaction`);
+      api.logger.warn(`No transaction ID found for scheduled transaction`);
       return;
     }
 
@@ -116,7 +116,7 @@ export class AccountUpdateStateHook implements Hook<PostOutputPreparationHookPar
     );
     const result = scheduledMirrorTx?.result;
     if (result !== MirrorTransactionResult.SUCCESS) {
-      logger.warn(
+      api.logger.warn(
         `Scheduled transaction result is not ${MirrorTransactionResult.SUCCESS}: ${String(result)}, skipping state update`,
       );
       return;
@@ -124,13 +124,13 @@ export class AccountUpdateStateHook implements Hook<PostOutputPreparationHookPar
 
     const entityId = scheduledMirrorTx?.entity_id;
     if (entityId && entityId !== normalisedParams.accountId) {
-      logger.warn(
+      api.logger.warn(
         `Account ID mismatch: expected ${normalisedParams.accountId}, got ${entityId}, skipping state update`,
       );
       return;
     }
 
-    this.persistAccountUpdate(api, logger, normalisedParams);
+    this.persistAccountUpdate(api, api.logger, normalisedParams);
   }
 
   private persistAccountUpdate(
@@ -151,11 +151,11 @@ export class AccountUpdateStateHook implements Hook<PostOutputPreparationHookPar
       return;
     }
 
-    const accountState = new ZustandAccountStateHelper(api.state, logger);
+    const accountState = new ZustandAccountStateHelper(api.state, api.logger);
     const existingAccount = accountState.getAccount(accountStateKey);
 
     if (!existingAccount) {
-      logger.warn(
+      api.logger.warn(
         `Account '${accountId}' not found in state, skipping state update`,
       );
       return;

--- a/src/plugins/account/hooks/account-update-state/handler.ts
+++ b/src/plugins/account/hooks/account-update-state/handler.ts
@@ -1,4 +1,4 @@
-import type { CoreApi, Logger } from '@/core';
+import type { CoreApi } from '@/core';
 import type { Hook, HookResult } from '@/core/hooks/hook.interface';
 import type { PostOutputPreparationHookParams } from '@/core/hooks/types';
 import type { AccountData } from '@/plugins/account/schema';
@@ -33,10 +33,10 @@ export class AccountUpdateStateHook implements Hook<PostOutputPreparationHookPar
 
     switch (parsed.data.source) {
       case OrchestratorSource.BATCH:
-        this.handleBatch(api, api.logger, parsed.data.batchData);
+        this.handleBatch(api, parsed.data.batchData);
         break;
       case OrchestratorSource.SCHEDULE:
-        await this.handleSchedule(api, api.logger, parsed.data.scheduledData);
+        await this.handleSchedule(api, parsed.data.scheduledData);
         break;
       default:
         break;
@@ -45,11 +45,7 @@ export class AccountUpdateStateHook implements Hook<PostOutputPreparationHookPar
     return { breakFlow: false };
   }
 
-  private handleBatch(
-    api: CoreApi,
-    logger: Logger,
-    batchData: BatchData,
-  ): void {
+  private handleBatch(api: CoreApi, batchData: BatchData): void {
     if (!batchData.success) {
       return;
     }
@@ -57,44 +53,41 @@ export class AccountUpdateStateHook implements Hook<PostOutputPreparationHookPar
       if (item.command !== ACCOUNT_UPDATE_COMMAND_NAME) {
         continue;
       }
-      this.updateFromBatchItem(api, api.logger, item);
+      this.updateFromBatchItem(api, item);
     }
   }
 
   private async handleSchedule(
     api: CoreApi,
-    logger: Logger,
     scheduledData: ScheduledTransactionData,
   ): Promise<void> {
     if (scheduledData.command !== ACCOUNT_UPDATE_COMMAND_NAME) {
       return;
     }
-    await this.updateFromScheduled(api, api.logger, scheduledData);
+    await this.updateFromScheduled(api, scheduledData);
   }
 
   private updateFromBatchItem(
     api: CoreApi,
-    logger: Logger,
     batchDataItem: BatchDataItem,
   ): void {
     const normalisedParams = this.parseAccountUpdateParams(
-      api.logger,
+      api,
       batchDataItem.normalizedParams,
     );
     if (!normalisedParams) {
       return;
     }
 
-    this.persistAccountUpdate(api, api.logger, normalisedParams);
+    this.persistAccountUpdate(api, normalisedParams);
   }
 
   private async updateFromScheduled(
     api: CoreApi,
-    logger: Logger,
     scheduledData: ScheduledTransactionData,
   ): Promise<void> {
     const normalisedParams = this.parseAccountUpdateParams(
-      api.logger,
+      api,
       scheduledData.normalizedParams ?? {},
     );
     if (!normalisedParams) {
@@ -130,12 +123,11 @@ export class AccountUpdateStateHook implements Hook<PostOutputPreparationHookPar
       return;
     }
 
-    this.persistAccountUpdate(api, api.logger, normalisedParams);
+    this.persistAccountUpdate(api, normalisedParams);
   }
 
   private persistAccountUpdate(
     api: CoreApi,
-    logger: Logger,
     normalisedParams: AccountUpdateNormalisedParams,
   ): void {
     const {
@@ -185,13 +177,13 @@ export class AccountUpdateStateHook implements Hook<PostOutputPreparationHookPar
   }
 
   private parseAccountUpdateParams(
-    logger: Logger,
+    api: CoreApi,
     normalizedParams: unknown,
   ): AccountUpdateNormalisedParams | undefined {
     const parseResult =
       AccountUpdateNormalisedParamsSchema.safeParse(normalizedParams);
     if (!parseResult.success) {
-      logger.warn(
+      api.logger.warn(
         `There was a problem with parsing data schema. The saving will not be done`,
       );
       return;

--- a/src/plugins/batch/__tests__/unit/helpers/mocks.ts
+++ b/src/plugins/batch/__tests__/unit/helpers/mocks.ts
@@ -62,9 +62,6 @@ export const makeArgs = (
 
   return {
     api: apiObject,
-    logger,
-    state: makeStateMock(),
-    config: makeConfigMock(),
     args,
     hooks: new Map(),
   };

--- a/src/plugins/batch/commands/create/handler.ts
+++ b/src/plugins/batch/commands/create/handler.ts
@@ -15,9 +15,9 @@ import { BatchCreateInputSchema } from './input';
 
 export class BatchCreateCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const batchState = new ZustandBatchStateHelper(api.state, logger);
+    const batchState = new ZustandBatchStateHelper(api.state, api.logger);
     const validArgs = BatchCreateInputSchema.parse(args.args);
     const name = validArgs.name;
     const batchKey = validArgs.key;

--- a/src/plugins/batch/commands/delete/handler.ts
+++ b/src/plugins/batch/commands/delete/handler.ts
@@ -14,9 +14,9 @@ import { BatchDeleteInputSchema } from './input';
 
 export class BatchDeleteCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const batchState = new ZustandBatchStateHelper(api.state, logger);
+    const batchState = new ZustandBatchStateHelper(api.state, api.logger);
     const validArgs = BatchDeleteInputSchema.parse(args.args);
     const name = validArgs.name;
     const order = validArgs.order;
@@ -45,7 +45,9 @@ export class BatchDeleteCommand implements Command {
       batch.transactions.splice(transactionIndex, 1);
       batchState.saveBatch(key, batch);
 
-      logger.info(`Removed transaction at order ${order} from batch '${name}'`);
+      api.logger.info(
+        `Removed transaction at order ${order} from batch '${name}'`,
+      );
 
       const outputData: BatchDeleteOutput = {
         name,
@@ -56,7 +58,7 @@ export class BatchDeleteCommand implements Command {
 
     // Delete whole batch
     batchState.deleteBatch(key);
-    logger.info(`Deleted batch '${name}'`);
+    api.logger.info(`Deleted batch '${name}'`);
 
     const outputData: BatchDeleteOutput = {
       name,

--- a/src/plugins/batch/commands/execute/handler.ts
+++ b/src/plugins/batch/commands/execute/handler.ts
@@ -45,8 +45,8 @@ export class BatchExecuteCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<BatchNormalisedParams> {
-    const { api, logger } = args;
-    const batchState = new ZustandBatchStateHelper(api.state, logger);
+    const { api } = args;
+    const batchState = new ZustandBatchStateHelper(api.state, api.logger);
     const validArgs = BatchExecuteInputSchema.parse(args.args);
     const name = validArgs.name;
     const network = api.network.getCurrentNetwork();
@@ -129,8 +129,8 @@ export class BatchExecuteCommand extends BaseTransactionCommand<
     _buildTransactionResult: BatchBuildTransactionResult,
     signTransactionResult: BatchSignTransactionResult,
   ): Promise<BatchExecuteTransactionResult> {
-    const { api, logger } = args;
-    const batchState = new ZustandBatchStateHelper(api.state, logger);
+    const { api } = args;
+    const batchState = new ZustandBatchStateHelper(api.state, api.logger);
     const result = await api.txExecute.execute(
       signTransactionResult.signedTransaction,
     );

--- a/src/plugins/batch/commands/list/handler.ts
+++ b/src/plugins/batch/commands/list/handler.ts
@@ -14,11 +14,11 @@ import { ZustandBatchStateHelper } from '@/plugins/batch/zustand-state-helper';
 
 export class BatchListCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const batchState = new ZustandBatchStateHelper(api.state, logger);
+    const batchState = new ZustandBatchStateHelper(api.state, api.logger);
 
-    logger.info('Listing all batches...');
+    api.logger.info('Listing all batches...');
 
     const batches = batchState.listBatches();
 

--- a/src/plugins/batch/hooks/batchify-add-transaction/handler.ts
+++ b/src/plugins/batch/hooks/batchify-add-transaction/handler.ts
@@ -33,13 +33,13 @@ export class BatchifyAddTransactionHook implements Hook<
   ): Promise<HookResult> {
     const { args, commandName, normalisedParams, signTransactionResult } =
       params;
-    const { api, logger } = args;
-    const batchState = new ZustandBatchStateHelper(api.state, logger);
+    const { api } = args;
+    const batchState = new ZustandBatchStateHelper(api.state, api.logger);
     const validArgs = BatchifyInputSchema.parse(args.args);
     const batchName = validArgs.batch;
     const network = api.network.getCurrentNetwork();
     if (!batchName) {
-      logger.debug(
+      api.logger.debug(
         'No parameter "batch" found. Transaction will not be added to batch.',
       );
       return Promise.resolve({ breakFlow: false });
@@ -75,7 +75,7 @@ export class BatchifyAddTransactionHook implements Hook<
     });
     batchState.saveBatch(key, batch);
 
-    logger.info(
+    api.logger.info(
       `Transaction added to batch '${batchName}' at position ${nextOrder}`,
     );
 

--- a/src/plugins/batch/hooks/batchify-set-batch-key/handler.ts
+++ b/src/plugins/batch/hooks/batchify-set-batch-key/handler.ts
@@ -23,13 +23,13 @@ export class BatchifySetBatchKeyHook implements Hook<
     >,
   ): Promise<HookResult> {
     const { args, buildTransactionResult } = params;
-    const { api, logger } = args;
-    const batchState = new ZustandBatchStateHelper(api.state, logger);
+    const { api } = args;
+    const batchState = new ZustandBatchStateHelper(api.state, api.logger);
     const validArgs = BatchifyInputSchema.parse(args.args);
     const batchName = validArgs.batch;
     const network = api.network.getCurrentNetwork();
     if (!batchName) {
-      logger.debug(
+      api.logger.debug(
         'No parameter "batch" found. Transaction will not be added to batch.',
       );
       return Promise.resolve({ breakFlow: false });

--- a/src/plugins/config/__tests__/unit/helpers/mocks.ts
+++ b/src/plugins/config/__tests__/unit/helpers/mocks.ts
@@ -6,7 +6,6 @@ import type { CommandHandlerArgs } from '@/core/plugins/plugin.interface';
 import type { ConfigService } from '@/core/services/config/config-service.interface';
 import type { IdentityResolutionService } from '@/core/services/identity-resolution/identity-resolution-service.interface';
 import type { Logger } from '@/core/services/logger/logger-service.interface';
-import type { StateService } from '@/core/services/state/state-service.interface';
 
 export const makeLogger = (): jest.Mocked<Logger> => ({
   info: jest.fn(),
@@ -52,8 +51,5 @@ export const makeCommandArgs = (params: {
     ...(params.args || {}),
   },
   api: params.api,
-  state: {} as unknown as StateService,
-  config: params.api.config,
-  logger: params.logger || makeLogger(),
   hooks: new Map(),
 });

--- a/src/plugins/contract/commands/create/handler.ts
+++ b/src/plugins/contract/commands/create/handler.ts
@@ -50,7 +50,7 @@ export class CreateContractCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<ContractCreateNormalisedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = ContractCreateSchema.parse(args.args);
     const alias = validArgs.name;
@@ -95,7 +95,7 @@ export class CreateContractCommand extends BaseTransactionCommand<
     const adminKeyThreshold = validArgs.adminKeyThreshold ?? adminKeys.length;
 
     if (adminKeys.length === 0) {
-      logger.warn(
+      api.logger.warn(
         `Admin key not specified. Smart contract will lack admin key set`,
       );
     }
@@ -235,7 +235,7 @@ export class CreateContractCommand extends BaseTransactionCommand<
     _signTransactionResult: ContractCreateSignTransactionResult,
     executeTransactionResult: ContractCreateExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
     if (!executeTransactionResult.contractId) {
       throw new StateError('Transaction completed but no contractId returned', {
@@ -249,7 +249,7 @@ export class CreateContractCommand extends BaseTransactionCommand<
     let verificationResult: ContractVerificationResult = { success: false };
 
     if (SupportedNetwork.LOCALNET === normalisedParams.network) {
-      logger.warn(
+      api.logger.warn(
         `Skipping contract verification as the selected network ${normalisedParams.network} is not supported `,
       );
     } else {
@@ -259,14 +259,14 @@ export class CreateContractCommand extends BaseTransactionCommand<
         contractEvmAddress: contractId.toEvmAddress(),
       });
       if (!verificationResult.success && verificationResult.errorMessage) {
-        logger.warn(
+        api.logger.warn(
           `Contract verification failed: ${verificationResult.errorMessage}`,
         );
       }
     }
 
     const contractEvmAddress = `0x${contractId.toEvmAddress()}`;
-    const contractState = new ZustandContractStateHelper(api.state, logger);
+    const contractState = new ZustandContractStateHelper(api.state, api.logger);
 
     const contractData = {
       contractId: executeTransactionResult.contractId,

--- a/src/plugins/contract/commands/delete/handler.ts
+++ b/src/plugins/contract/commands/delete/handler.ts
@@ -115,8 +115,8 @@ export class DeleteContractCommand extends BaseTransactionCommand<
     stateKey: string;
     contractRef: string;
   } {
-    const { api, logger } = args;
-    const contractState = new ZustandContractStateHelper(api.state, logger);
+    const { api } = args;
+    const contractState = new ZustandContractStateHelper(api.state, api.logger);
     const validArgs = parsedInput ?? ContractDeleteInputSchema.parse(args.args);
     const contractRef = validArgs.contract;
     const network = api.network.getCurrentNetwork();
@@ -146,8 +146,8 @@ export class DeleteContractCommand extends BaseTransactionCommand<
     contractRef: string;
     mirrorContractInfo: ContractInfo | null;
   }> {
-    const { api, logger } = args;
-    const contractState = new ZustandContractStateHelper(api.state, logger);
+    const { api } = args;
+    const contractState = new ZustandContractStateHelper(api.state, api.logger);
     const validArgs = parsedInput ?? ContractDeleteInputSchema.parse(args.args);
     const contractRef = validArgs.contract;
     const network = api.network.getCurrentNetwork();
@@ -186,7 +186,7 @@ export class DeleteContractCommand extends BaseTransactionCommand<
       memo: contractInfo.memo || undefined,
     };
 
-    logger.info(
+    api.logger.info(
       `Contract not in local state; using mirror info for ${contractToDelete.contractId}`,
     );
 

--- a/src/plugins/contract/commands/import/handler.ts
+++ b/src/plugins/contract/commands/import/handler.ts
@@ -19,9 +19,9 @@ import { ContractImportInputSchema } from './input';
 
 export class ImportContractCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const contractState = new ZustandContractStateHelper(api.state, logger);
+    const contractState = new ZustandContractStateHelper(api.state, api.logger);
 
     const validArgs = ContractImportInputSchema.parse(args.args);
 
@@ -61,7 +61,7 @@ export class ImportContractCommand implements Command {
         contractEvmAddress,
       );
 
-    logger.info(`Importing contract ${contractId}`);
+    api.logger.info(`Importing contract ${contractId}`);
 
     if (name) {
       api.alias.register({

--- a/src/plugins/contract/commands/list/handler.ts
+++ b/src/plugins/contract/commands/list/handler.ts
@@ -10,19 +10,19 @@ import { ZustandContractStateHelper } from '@/plugins/contract/zustand-state-hel
 
 export class ListContractsCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const contractState = new ZustandContractStateHelper(api.state, logger);
+    const contractState = new ZustandContractStateHelper(api.state, api.logger);
 
-    logger.info('Listing contracts...');
+    api.logger.info('Listing contracts...');
 
     const contracts = contractState.listContracts();
-    logger.debug(
+    api.logger.debug(
       `[CONTRACT LIST] Retrieved ${contracts.length} contracts from state`,
     );
 
     contracts.forEach((contract, index) => {
-      logger.debug(
+      api.logger.debug(
         `[CONTRACT LIST]   ${index + 1}. ${contract.name ?? contract.contractId} - ${contract.contractId} on ${contract.network}`,
       );
     });

--- a/src/plugins/contract/commands/update/handler.ts
+++ b/src/plugins/contract/commands/update/handler.ts
@@ -48,7 +48,7 @@ export class UpdateContractCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<ContractUpdateNormalisedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = ContractUpdateInputSchema.parse(args.args);
     const network = api.network.getCurrentNetwork();
@@ -69,7 +69,7 @@ export class UpdateContractCommand extends BaseTransactionCommand<
     const contractId = contractInfo.contract_id;
     const stateKey = composeKey(network, contractId);
 
-    const contractState = new ZustandContractStateHelper(api.state, logger);
+    const contractState = new ZustandContractStateHelper(api.state, api.logger);
     let storedContract = contractState.getContract(stateKey);
 
     const keyManager =
@@ -89,7 +89,7 @@ export class UpdateContractCommand extends BaseTransactionCommand<
         contractId,
         network,
       );
-      logger.info(
+      api.logger.info(
         `Contract not in local state; using mirror info for ${storedContract.contractId}`,
       );
     }
@@ -224,8 +224,8 @@ export class UpdateContractCommand extends BaseTransactionCommand<
     _signTransactionResult: ContractUpdateSignTransactionResult,
     executeTransactionResult: ContractUpdateExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
-    const contractState = new ZustandContractStateHelper(api.state, logger);
+    const { api } = args;
+    const contractState = new ZustandContractStateHelper(api.state, api.logger);
     const existingContract = contractState.getContract(
       normalisedParams.stateKey,
     );

--- a/src/plugins/credentials/commands/list/handler.ts
+++ b/src/plugins/credentials/commands/list/handler.ts
@@ -4,9 +4,9 @@ import type { CredentialsListOutput } from './output';
 
 export class CredentialsListCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { logger, api } = args;
+    const { api } = args;
 
-    logger.info('🔐 Retrieving stored credentials...');
+    api.logger.info('🔐 Retrieving stored credentials...');
 
     const credentials = api.kms.list();
 

--- a/src/plugins/credentials/commands/remove/handler.ts
+++ b/src/plugins/credentials/commands/remove/handler.ts
@@ -8,11 +8,11 @@ import { CredentialsRemoveInputSchema } from './input';
 
 export class CredentialsRemoveCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { logger, api } = args;
+    const { api } = args;
 
     const { id } = CredentialsRemoveInputSchema.parse(args.args);
 
-    logger.info(`🗑️  Removing credentials for id: ${id}`);
+    api.logger.info(`🗑️  Removing credentials for id: ${id}`);
 
     const publicKey = api.kms.get(id)?.publicKey;
     if (!publicKey) {

--- a/src/plugins/hbar/commands/allowance-revoke/handler.ts
+++ b/src/plugins/hbar/commands/allowance-revoke/handler.ts
@@ -36,9 +36,9 @@ export class HbarAllowanceRevokeCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<AllowanceRevokeNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    logger.info('[HBAR] Allowance revoke command invoked');
+    api.logger.info('[HBAR] Allowance revoke command invoked');
 
     const validArgs = HbarAllowanceRevokeInputSchema.parse(args.args);
     const keyManager =
@@ -64,7 +64,7 @@ export class HbarAllowanceRevokeCommand extends BaseTransactionCommand<
       );
     }
 
-    logger.info(
+    api.logger.info(
       `[HBAR] Revoking allowance for spender ${resolvedSpender.accountId}`,
     );
 
@@ -132,9 +132,9 @@ export class HbarAllowanceRevokeCommand extends BaseTransactionCommand<
     _signResult: AllowanceRevokeSignTransactionResult,
     executeResult: AllowanceRevokeExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { logger } = args;
+    const { api } = args;
 
-    logger.info(
+    api.logger.info(
       `[HBAR] Allowance revoked successfully, txId=${executeResult.transactionId}`,
     );
 

--- a/src/plugins/hbar/commands/allowance/handler.ts
+++ b/src/plugins/hbar/commands/allowance/handler.ts
@@ -38,9 +38,9 @@ export class HbarAllowanceCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<AllowanceNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    logger.info('[HBAR] Allowance command invoked');
+    api.logger.info('[HBAR] Allowance command invoked');
 
     const validArgs = HbarAllowanceInputSchema.parse(args.args);
     const keyManager =
@@ -67,7 +67,7 @@ export class HbarAllowanceCommand extends BaseTransactionCommand<
       );
     }
 
-    logger.info(
+    api.logger.info(
       `[HBAR] Approving ${amountTinybar} tinybars for spender ${resolvedSpender.accountId}`,
     );
 
@@ -136,9 +136,9 @@ export class HbarAllowanceCommand extends BaseTransactionCommand<
     _signResult: AllowanceSignTransactionResult,
     executeResult: AllowanceExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { logger } = args;
+    const { api } = args;
 
-    logger.info(
+    api.logger.info(
       `[HBAR] Allowance approved successfully, txId=${executeResult.transactionId}`,
     );
 

--- a/src/plugins/hbar/commands/transfer/handler.ts
+++ b/src/plugins/hbar/commands/transfer/handler.ts
@@ -38,9 +38,9 @@ export class HbarTransferCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TransferNormalisedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    logger.info('[HBAR] Transfer command invoked');
+    api.logger.info('[HBAR] Transfer command invoked');
 
     const validArgs = HbarTransferInputSchema.parse(args.args);
 
@@ -85,9 +85,9 @@ export class HbarTransferCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: TransferNormalisedParams,
   ): Promise<TransferBuildTransactionResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    logger.info(
+    api.logger.info(
       `[HBAR] Transferring ${normalisedParams.amount.toString()} tinybars from ${normalisedParams.fromAccount.accountId} to ${normalisedParams.destination}`,
     );
 
@@ -144,9 +144,9 @@ export class HbarTransferCommand extends BaseTransactionCommand<
     _signTransactionResult: TransferSignTransactionResult,
     executeTransactionResult: TransferExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { logger } = args;
+    const { api } = args;
 
-    logger.info(
+    api.logger.info(
       `[HBAR] Transfer submitted successfully, txId=${executeTransactionResult.transactionId}`,
     );
 

--- a/src/plugins/network/commands/get-operator/handler.ts
+++ b/src/plugins/network/commands/get-operator/handler.ts
@@ -32,10 +32,10 @@ const normalizeParams = (
 
 export class NetworkGetOperatorCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { logger, api } = args;
+    const { api } = args;
     const normalisedParams = normalizeParams(args);
 
-    logger.info(
+    api.logger.info(
       `Getting operator for network: ${normalisedParams.targetNetwork}`,
     );
 

--- a/src/plugins/network/commands/set-operator/handler.ts
+++ b/src/plugins/network/commands/set-operator/handler.ts
@@ -44,7 +44,7 @@ const normalizeParams = (
 
 export class NetworkSetOperatorCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { logger, api } = args;
+    const { api } = args;
     const normalisedParams = normalizeParams(args);
     const operator = await api.keyResolver.resolveAccountCredentials(
       normalisedParams.operatorArg,
@@ -58,11 +58,11 @@ export class NetworkSetOperatorCommand implements Command {
     };
 
     if (executeContext.existingOperator) {
-      logger.info(
+      api.logger.info(
         `Overwriting existing operator for ${normalisedParams.targetNetwork}: ${executeContext.existingOperator.accountId} -> ${executeContext.operator.accountId}`,
       );
     } else {
-      logger.info(
+      api.logger.info(
         `Setting new operator for network ${normalisedParams.targetNetwork}`,
       );
     }

--- a/src/plugins/network/commands/use/handler.ts
+++ b/src/plugins/network/commands/use/handler.ts
@@ -19,10 +19,10 @@ const normalizeParams = (
 
 export class NetworkUseCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { logger, api } = args;
+    const { api } = args;
     const normalisedParams = normalizeParams(args);
 
-    logger.info(`Switching to network: ${normalisedParams.network}`);
+    api.logger.info(`Switching to network: ${normalisedParams.network}`);
     api.network.switchNetwork(normalisedParams.network);
 
     const output: UseNetworkOutput = {

--- a/src/plugins/plugin-management/commands/add/handler.ts
+++ b/src/plugins/plugin-management/commands/add/handler.ts
@@ -27,22 +27,22 @@ import { PluginManagementAddInputSchema } from './input';
 
 export class PluginManagementAddCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = PluginManagementAddInputSchema.parse(args.args);
 
     let pluginPath: string;
     if (validArgs.name) {
       pluginPath = resolveDefaultPluginPath(validArgs.name);
-      logger.info(`➕ Adding default plugin: ${validArgs.name}...`);
+      api.logger.info(`➕ Adding default plugin: ${validArgs.name}...`);
     } else {
       pluginPath = validArgs.path!;
-      logger.info('➕ Adding plugin from path...');
+      api.logger.info('➕ Adding plugin from path...');
     }
 
     const { resolvedPath, manifestPath } = await validatePluginPath(pluginPath);
 
-    logger.info(`🔍 Loading plugin manifest from: ${manifestPath}`);
+    api.logger.info(`🔍 Loading plugin manifest from: ${manifestPath}`);
 
     const manifest = await loadPluginManifest(manifestPath);
     const pluginName = manifest.name;

--- a/src/plugins/plugin-management/commands/disable/handler.ts
+++ b/src/plugins/plugin-management/commands/disable/handler.ts
@@ -14,12 +14,12 @@ import { PluginManagementDisableInputSchema } from './input';
 
 export class PluginManagementDisableCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = PluginManagementDisableInputSchema.parse(args.args);
     const name = validArgs.name;
 
-    logger.info('➖ Disabling plugin...');
+    api.logger.info('➖ Disabling plugin...');
 
     const result = api.pluginManagement.disablePlugin(name);
 

--- a/src/plugins/plugin-management/commands/enable/handler.ts
+++ b/src/plugins/plugin-management/commands/enable/handler.ts
@@ -14,12 +14,12 @@ import { PluginManagementEnableInputSchema } from './input';
 
 export class PluginManagementEnableCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = PluginManagementEnableInputSchema.parse(args.args);
     const name = validArgs.name;
 
-    logger.info('✅ Enabling plugin...');
+    api.logger.info('✅ Enabling plugin...');
 
     const result = api.pluginManagement.enablePlugin(name);
 

--- a/src/plugins/plugin-management/commands/info/handler.ts
+++ b/src/plugins/plugin-management/commands/info/handler.ts
@@ -20,12 +20,12 @@ import { PluginManagementInfoInputSchema } from './input';
 
 export class PluginManagementInfoCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = PluginManagementInfoInputSchema.parse(args.args);
     const name = validArgs.name;
 
-    logger.info(`ℹ️  Getting plugin information: ${name}`);
+    api.logger.info(`ℹ️  Getting plugin information: ${name}`);
 
     const pluginManagement = api.pluginManagement;
     const entry: PluginStateEntry | undefined =
@@ -41,7 +41,9 @@ export class PluginManagementInfoCommand implements Command {
       entry.path ?? path.resolve(__dirname, '../../../../plugins', entry.name);
     const manifestPath = path.resolve(basePath, 'manifest.js');
 
-    logger.info(`🔍 Loading plugin manifest for info from: ${manifestPath}`);
+    api.logger.info(
+      `🔍 Loading plugin manifest for info from: ${manifestPath}`,
+    );
 
     const manifest = await loadPluginManifest(manifestPath);
 

--- a/src/plugins/plugin-management/commands/list/handler.ts
+++ b/src/plugins/plugin-management/commands/list/handler.ts
@@ -8,9 +8,9 @@ import type { PluginManagementListOutput } from './output';
 
 export class PluginManagementListCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    logger.info('📋 Getting plugin list...');
+    api.logger.info('📋 Getting plugin list...');
 
     const entries = api.pluginManagement.listPlugins();
 

--- a/src/plugins/plugin-management/commands/remove/handler.ts
+++ b/src/plugins/plugin-management/commands/remove/handler.ts
@@ -14,12 +14,12 @@ import { PluginManagementRemoveInputSchema } from './input';
 
 export class PluginManagementRemoveCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = PluginManagementRemoveInputSchema.parse(args.args);
     const name = validArgs.name;
 
-    logger.info('🗑️ Removing plugin from state...');
+    api.logger.info('🗑️ Removing plugin from state...');
 
     const result = api.pluginManagement.removePlugin(name);
 

--- a/src/plugins/plugin-management/commands/reset/handler.ts
+++ b/src/plugins/plugin-management/commands/reset/handler.ts
@@ -9,9 +9,9 @@ import type { PluginManagementResetOutput } from './output';
 
 export class PluginManagementResetCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    logger.info('🔄 Resetting plugin state...');
+    api.logger.info('🔄 Resetting plugin state...');
 
     api.pluginManagement.resetPlugins();
 

--- a/src/plugins/schedule/__tests__/unit/helpers/mocks.ts
+++ b/src/plugins/schedule/__tests__/unit/helpers/mocks.ts
@@ -36,9 +36,6 @@ export const makeScheduleArgs = (
 
   return {
     api: apiObject,
-    logger,
-    state: makeStateMock(),
-    config: makeConfigMock(),
     args,
     hooks: new Map(),
   };

--- a/src/plugins/schedule/commands/create/handler.ts
+++ b/src/plugins/schedule/commands/create/handler.ts
@@ -16,9 +16,9 @@ import { ScheduleCreateInputSchema } from './input';
 
 export class ScheduleCreateCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const scheduleState = new ZustandScheduleStateHelper(api.state, logger);
+    const scheduleState = new ZustandScheduleStateHelper(api.state, api.logger);
     const validArgs = ScheduleCreateInputSchema.parse(args.args);
     const name = validArgs.name;
     const network = api.network.getCurrentNetwork();

--- a/src/plugins/schedule/commands/delete/handler.ts
+++ b/src/plugins/schedule/commands/delete/handler.ts
@@ -197,10 +197,10 @@ export class ScheduleDeleteCommand extends BaseTransactionCommand<
     _signTransactionResult: ScheduleDeleteSignTransactionResult,
     executeTransactionResult: ScheduleDeleteExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
     if (normalisedParams.scheduleName) {
-      const stateHelper = new ZustandScheduleStateHelper(api.state, logger);
+      const stateHelper = new ZustandScheduleStateHelper(api.state, api.logger);
       stateHelper.deleteScheduled(
         composeKey(normalisedParams.network, normalisedParams.scheduleName),
       );

--- a/src/plugins/schedule/hooks/scheduled/handler.ts
+++ b/src/plugins/schedule/hooks/scheduled/handler.ts
@@ -26,13 +26,16 @@ export class ScheduledHook implements Hook<
     >,
   ): Promise<HookResult> {
     const { args, commandName, buildTransactionResult } = params;
-    const { api, logger } = args;
-    const scheduledState = new ZustandScheduleStateHelper(api.state, logger);
+    const { api } = args;
+    const scheduledState = new ZustandScheduleStateHelper(
+      api.state,
+      api.logger,
+    );
     const validArgs = ScheduledInputSchema.parse(args.args);
     const scheduledName = validArgs.scheduled;
     const network = api.network.getCurrentNetwork();
     if (!scheduledName) {
-      logger.debug(
+      api.logger.debug(
         'No parameter "scheduled" found. Transaction will not be scheduled.',
       );
       return { breakFlow: false };
@@ -89,7 +92,7 @@ export class ScheduledHook implements Hook<
       executed: false,
     });
 
-    logger.info(
+    api.logger.info(
       `Transaction scheduled for ${scheduledName}. Transaction ID '${result.transactionId.toString()}'`,
     );
 

--- a/src/plugins/swap/__tests__/unit/helpers/mocks.ts
+++ b/src/plugins/swap/__tests__/unit/helpers/mocks.ts
@@ -70,9 +70,6 @@ export const makeArgs = (
 
   return {
     api: apiObject,
-    logger,
-    state: makeStateMock(),
-    config: makeConfigMock(),
     args,
     hooks: new Map(),
   };

--- a/src/plugins/test/commands/foo/handler.ts
+++ b/src/plugins/test/commands/foo/handler.ts
@@ -56,8 +56,8 @@ export class TestFooCommand extends BaseTransactionCommand<
   ): Promise<void> {
     void normalisedParams;
     void buildTransactionResult;
-    const { logger } = args;
-    logger.info(signTransactionResult.message);
+    const { api } = args;
+    api.logger.info(signTransactionResult.message);
   }
 
   async outputPreparation(

--- a/src/plugins/test/commands/memo/handler.ts
+++ b/src/plugins/test/commands/memo/handler.ts
@@ -9,9 +9,9 @@ import { ZustandMemoStateHelper } from '@/plugins/test/zustand-state-helper';
 export async function testMemo(
   args: CommandHandlerArgs,
 ): Promise<CommandResult> {
-  const { api, logger } = args;
+  const { api } = args;
 
-  const memoState = new ZustandMemoStateHelper(api.state, logger);
+  const memoState = new ZustandMemoStateHelper(api.state, api.logger);
 
   const validArgs = TestMemoInputSchema.parse(args.args);
   const memo = validArgs.memo;

--- a/src/plugins/token/__tests__/unit/airdrop-ft.test.ts
+++ b/src/plugins/token/__tests__/unit/airdrop-ft.test.ts
@@ -2,7 +2,6 @@ import type { CommandHandlerArgs } from '@/core/plugins/plugin.interface';
 
 import '@/core/utils/json-serialize';
 
-import { makeConfigMock, makeStateMock } from '@/__tests__/mocks/mocks';
 import { assertOutput } from '@/__tests__/utils/assert-output';
 import { TransactionError, ValidationError } from '@/core/errors';
 import {
@@ -11,7 +10,7 @@ import {
 } from '@/plugins/token/commands/airdrop-ft';
 
 import { mockTransactionResults } from './helpers/fixtures';
-import { makeApiMocks, makeLogger } from './helpers/mocks';
+import { makeApiMocks } from './helpers/mocks';
 
 describe('tokenAirdropFt', () => {
   const mockAirdropTransaction = { test: 'airdrop-transaction' };
@@ -54,9 +53,6 @@ describe('tokenAirdropFt', () => {
           amount: ['100'],
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       const result = await tokenAirdropFt(args);
@@ -106,9 +102,6 @@ describe('tokenAirdropFt', () => {
           amount: ['10', '20', '30'],
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       const result = await tokenAirdropFt(args);
@@ -153,9 +146,6 @@ describe('tokenAirdropFt', () => {
           amount: ['50'],
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       const result = await tokenAirdropFt(args);
@@ -201,9 +191,6 @@ describe('tokenAirdropFt', () => {
           amount: ['100'],
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       const result = await tokenAirdropFt(args);
@@ -235,9 +222,6 @@ describe('tokenAirdropFt', () => {
           amount: ['500t'],
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       const result = await tokenAirdropFt(args);
@@ -277,9 +261,6 @@ describe('tokenAirdropFt', () => {
           amount: ['100'],
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       const result = await tokenAirdropFt(args);
@@ -303,9 +284,6 @@ describe('tokenAirdropFt', () => {
           amount: ['100'],
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       await expect(tokenAirdropFt(args)).rejects.toThrow(
@@ -334,9 +312,6 @@ describe('tokenAirdropFt', () => {
           amount: amounts,
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       await expect(tokenAirdropFt(args)).rejects.toThrow(ValidationError);
@@ -359,9 +334,6 @@ describe('tokenAirdropFt', () => {
           amount: ['100'],
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       await expect(tokenAirdropFt(args)).rejects.toThrow(
@@ -384,9 +356,6 @@ describe('tokenAirdropFt', () => {
           amount: ['100t'],
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       await expect(tokenAirdropFt(args)).rejects.toThrow(
@@ -420,9 +389,6 @@ describe('tokenAirdropFt', () => {
           amount: ['100t'],
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       await expect(tokenAirdropFt(args)).rejects.toThrow(TransactionError);

--- a/src/plugins/token/__tests__/unit/airdrop-nft.test.ts
+++ b/src/plugins/token/__tests__/unit/airdrop-nft.test.ts
@@ -19,11 +19,7 @@ import {
   TokenAirdropNftOutputSchema,
 } from '@/plugins/token/commands/airdrop-nft';
 
-import {
-  makeApiMocks,
-  makeLogger,
-  makeTransactionResult,
-} from './helpers/mocks';
+import { makeApiMocks, makeTransactionResult } from './helpers/mocks';
 
 const TOKEN_ID = MOCK_HEDERA_ENTITY_ID_1;
 const SENDER_ACCOUNT_ID = MOCK_ACCOUNT_ID;
@@ -69,7 +65,6 @@ describe('tokenAirdropNft', () => {
   describe('success scenarios', () => {
     test('should airdrop single serial to single recipient using account-id:private-key format', async () => {
       const { api, tokens } = makeAirdropSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -79,9 +74,6 @@ describe('tokenAirdropNft', () => {
           from: SENDER_WITH_KEY,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenAirdropNft(args);
@@ -103,7 +95,6 @@ describe('tokenAirdropNft', () => {
 
     test('should airdrop multiple serials to single recipient', async () => {
       const { api, tokens } = makeAirdropSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -113,9 +104,6 @@ describe('tokenAirdropNft', () => {
           from: SENDER_WITH_KEY,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenAirdropNft(args);
@@ -134,7 +122,6 @@ describe('tokenAirdropNft', () => {
 
     test('should airdrop to multiple recipients with different serials', async () => {
       const { api, tokens } = makeAirdropSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -144,9 +131,6 @@ describe('tokenAirdropNft', () => {
           from: SENDER_WITH_KEY,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenAirdropNft(args);
@@ -174,7 +158,6 @@ describe('tokenAirdropNft', () => {
 
     test('should use operator as sender when --from is not provided', async () => {
       const { api, tokens } = makeAirdropSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -183,9 +166,6 @@ describe('tokenAirdropNft', () => {
           serials: ['1'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenAirdropNft(args);
@@ -221,7 +201,6 @@ describe('tokenAirdropNft', () => {
           }),
         },
       });
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -230,9 +209,6 @@ describe('tokenAirdropNft', () => {
           serials: ['5'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenAirdropNft(args);
@@ -261,7 +237,6 @@ describe('tokenAirdropNft', () => {
           }),
         },
       });
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -270,9 +245,6 @@ describe('tokenAirdropNft', () => {
           serials: ['1'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenAirdropNft(args);
@@ -288,7 +260,6 @@ describe('tokenAirdropNft', () => {
   describe('validation errors', () => {
     test('should throw ValidationError when to/serials count mismatch', async () => {
       const { api } = makeAirdropSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -297,9 +268,6 @@ describe('tokenAirdropNft', () => {
           serials: ['1'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAirdropNft(args)).rejects.toThrow(
@@ -309,7 +277,6 @@ describe('tokenAirdropNft', () => {
 
     test('should throw ValidationError when duplicate serials across recipients', async () => {
       const { api } = makeAirdropSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -318,9 +285,6 @@ describe('tokenAirdropNft', () => {
           serials: ['1,2', '2,3'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAirdropNft(args)).rejects.toThrow(
@@ -330,7 +294,6 @@ describe('tokenAirdropNft', () => {
 
     test('should throw ValidationError when total serials exceed 20', async () => {
       const { api } = makeAirdropSuccessMocks();
-      const logger = makeLogger();
 
       const serials = Array.from({ length: 3 }, (_, i) =>
         Array.from({ length: 7 }, (__, j) => i * 7 + j + 1).join(','),
@@ -344,9 +307,6 @@ describe('tokenAirdropNft', () => {
           serials,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAirdropNft(args)).rejects.toThrow(ValidationError);
@@ -369,7 +329,6 @@ describe('tokenAirdropNft', () => {
         },
         alias: { resolve: jest.fn().mockReturnValue(null) },
       });
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -378,9 +337,6 @@ describe('tokenAirdropNft', () => {
           serials: ['1'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAirdropNft(args)).rejects.toThrow(ValidationError);
@@ -395,7 +351,6 @@ describe('tokenAirdropNft', () => {
       const { api } = makeApiMocks({
         alias: { resolve: jest.fn().mockReturnValue(null) },
       });
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -404,9 +359,6 @@ describe('tokenAirdropNft', () => {
           serials: ['1'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAirdropNft(args)).rejects.toThrow(NotFoundError);
@@ -426,7 +378,6 @@ describe('tokenAirdropNft', () => {
           }),
         },
       });
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -435,9 +386,6 @@ describe('tokenAirdropNft', () => {
           serials: ['1'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAirdropNft(args)).rejects.toThrow(NotFoundError);
@@ -463,7 +411,6 @@ describe('tokenAirdropNft', () => {
         mirror: makeNftMirrorMock(),
         alias: { resolve: jest.fn().mockReturnValue(null) },
       });
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -472,9 +419,6 @@ describe('tokenAirdropNft', () => {
           serials: ['1'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAirdropNft(args)).rejects.toThrow(TransactionError);

--- a/src/plugins/token/__tests__/unit/allowance-ft.test.ts
+++ b/src/plugins/token/__tests__/unit/allowance-ft.test.ts
@@ -8,7 +8,6 @@ import {
   MOCK_ACCOUNT_ID_ALT,
   MOCK_HEDERA_ENTITY_ID_1,
 } from '@/__tests__/mocks/fixtures';
-import { makeConfigMock, makeStateMock } from '@/__tests__/mocks/mocks';
 import { assertOutput } from '@/__tests__/utils/assert-output';
 import { NetworkError } from '@/core';
 import { FtAllowanceEntry } from '@/core/services/allowance';
@@ -20,7 +19,7 @@ import {
 } from '@/plugins/token/commands/allowance-ft';
 
 import { mockTransactionResults } from './helpers/fixtures';
-import { makeApiMocks, makeLogger } from './helpers/mocks';
+import { makeApiMocks } from './helpers/mocks';
 
 const TOKEN_ID = MOCK_HEDERA_ENTITY_ID_1;
 const OWNER_ACCOUNT_ID = MOCK_ACCOUNT_ID;
@@ -58,7 +57,6 @@ describe('tokenAllowanceFt', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: TOKEN_ID,
@@ -67,9 +65,6 @@ describe('tokenAllowanceFt', () => {
           amount: '100',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenAllowanceFt(args);
@@ -122,7 +117,6 @@ describe('tokenAllowanceFt', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: TOKEN_ID,
@@ -131,9 +125,6 @@ describe('tokenAllowanceFt', () => {
           amount: '500t',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenAllowanceFt(args);
@@ -174,7 +165,6 @@ describe('tokenAllowanceFt', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: TOKEN_ID,
@@ -183,9 +173,6 @@ describe('tokenAllowanceFt', () => {
           amount: '0',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenAllowanceFt(args);
@@ -236,7 +223,6 @@ describe('tokenAllowanceFt', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: TOKEN_ID,
@@ -245,9 +231,6 @@ describe('tokenAllowanceFt', () => {
           amount: '100',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenAllowanceFt(args);
@@ -285,7 +268,6 @@ describe('tokenAllowanceFt', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: TOKEN_ID,
@@ -294,9 +276,6 @@ describe('tokenAllowanceFt', () => {
           amount: '100',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       await expect(tokenAllowanceFt(args)).rejects.toThrow();
@@ -321,7 +300,6 @@ describe('tokenAllowanceFt', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: TOKEN_ID,
@@ -330,9 +308,6 @@ describe('tokenAllowanceFt', () => {
           amount: '100',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       await expect(tokenAllowanceFt(args)).rejects.toThrow('Network error');

--- a/src/plugins/token/__tests__/unit/allowance-nft.test.ts
+++ b/src/plugins/token/__tests__/unit/allowance-nft.test.ts
@@ -23,7 +23,6 @@ import {
 
 import {
   makeApiMocks,
-  makeLogger,
   makeTransactionResult,
   MOCK_NFT_COLLECTION_ENTITY_ID,
 } from './helpers/mocks';
@@ -90,7 +89,6 @@ describe('tokenAllowanceNft', () => {
   describe('success scenarios', () => {
     test('approve specific serials with account-id:key format', async () => {
       const { api, allowance } = makeAllowanceSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -100,9 +98,6 @@ describe('tokenAllowanceNft', () => {
           serials: '1,2,3',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenAllowanceNft(args);
@@ -128,7 +123,6 @@ describe('tokenAllowanceNft', () => {
 
     test('approve all serials with all-serials flag', async () => {
       const { api, allowance } = makeAllowanceSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -138,9 +132,6 @@ describe('tokenAllowanceNft', () => {
           allSerials: true,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenAllowanceNft(args);
@@ -163,7 +154,6 @@ describe('tokenAllowanceNft', () => {
     test('owner defaults to operator when not provided', async () => {
       const operatorId = MOCK_OPERATOR_ACCOUNT_ID;
       const { api, allowance } = makeAllowanceSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -172,9 +162,6 @@ describe('tokenAllowanceNft', () => {
           serials: '5',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenAllowanceNft(args);
@@ -194,7 +181,6 @@ describe('tokenAllowanceNft', () => {
 
     test('resolve token and spender by alias', async () => {
       const { api, allowance } = makeAllowanceSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -204,9 +190,6 @@ describe('tokenAllowanceNft', () => {
           serials: '10',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenAllowanceNft(args);
@@ -232,7 +215,6 @@ describe('tokenAllowanceNft', () => {
       (api.mirror.getTokenInfo as jest.Mock).mockResolvedValue({
         type: 'FUNGIBLE_COMMON',
       });
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -241,9 +223,6 @@ describe('tokenAllowanceNft', () => {
           serials: '1',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAllowanceNft(args)).rejects.toThrow(ValidationError);
@@ -252,7 +231,6 @@ describe('tokenAllowanceNft', () => {
     test('throws NotFoundError when spender account not found', async () => {
       const { api } = makeAllowanceSuccessMocks();
       (api.alias.resolve as jest.Mock).mockReturnValue(null);
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -262,9 +240,6 @@ describe('tokenAllowanceNft', () => {
           serials: '1',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAllowanceNft(args)).rejects.toThrow(NotFoundError);
@@ -275,7 +250,6 @@ describe('tokenAllowanceNft', () => {
       (api.txExecute.execute as jest.Mock).mockResolvedValue(
         makeTransactionResult({ success: false, transactionId: '' }),
       );
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -285,9 +259,6 @@ describe('tokenAllowanceNft', () => {
           serials: '1',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAllowanceNft(args)).rejects.toThrow(TransactionError);
@@ -295,7 +266,6 @@ describe('tokenAllowanceNft', () => {
 
     test('throws ZodError when neither serials nor all-serials specified', async () => {
       const { api } = makeAllowanceSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -303,9 +273,6 @@ describe('tokenAllowanceNft', () => {
           spender: MOCK_ACCOUNT_ID_ALT,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAllowanceNft(args)).rejects.toThrow(
@@ -315,7 +282,6 @@ describe('tokenAllowanceNft', () => {
 
     test('throws ZodError when both serials and all-serials specified', async () => {
       const { api } = makeAllowanceSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -325,9 +291,6 @@ describe('tokenAllowanceNft', () => {
           allSerials: true,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAllowanceNft(args)).rejects.toThrow(

--- a/src/plugins/token/__tests__/unit/associate.test.ts
+++ b/src/plugins/token/__tests__/unit/associate.test.ts
@@ -14,11 +14,7 @@ import {
   TokenAssociateOutputSchema,
 } from '@/plugins/token/commands/associate';
 
-import {
-  makeApiMocks,
-  makeLogger,
-  makeTransactionResult,
-} from './helpers/mocks';
+import { makeApiMocks, makeTransactionResult } from './helpers/mocks';
 
 describe('tokenAssociateHandler', () => {
   describe('success scenarios', () => {
@@ -48,7 +44,6 @@ describe('tokenAssociateHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: '0.0.123456',
@@ -56,9 +51,6 @@ describe('tokenAssociateHandler', () => {
             '0.0.789012:3333333333333333333333333333333333333333333333333333333333333333',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenAssociate(args);
@@ -110,16 +102,12 @@ describe('tokenAssociateHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: '0.0.123456',
           account: 'alice',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenAssociate(args);
@@ -166,16 +154,12 @@ describe('tokenAssociateHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: tokenId,
           account: `${accountId}:3333333333333333333333333333333333333333333333333333333333333333`,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAssociate(args)).rejects.toThrow(ValidationError);
@@ -206,16 +190,12 @@ describe('tokenAssociateHandler', () => {
         txExecute: { execute: txExecuteExecute },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: tokenId,
           account: `${accountId}:3333333333333333333333333333333333333333333333333333333333333333`,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAssociate(args)).rejects.toThrow(ValidationError);
@@ -253,7 +233,6 @@ describe('tokenAssociateHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: '0.0.123456',
@@ -261,9 +240,6 @@ describe('tokenAssociateHandler', () => {
             '0.0.789012:3333333333333333333333333333333333333333333333333333333333333333',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAssociate(args)).rejects.toThrow(TransactionError);
@@ -291,7 +267,6 @@ describe('tokenAssociateHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: '0.0.123456',
@@ -299,9 +274,6 @@ describe('tokenAssociateHandler', () => {
             '0.0.789012:3333333333333333333333333333333333333333333333333333333333333333',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAssociate(args)).rejects.toThrow('Service unavailable');
@@ -332,7 +304,6 @@ describe('tokenAssociateHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: '0.0.123456',
@@ -340,9 +311,6 @@ describe('tokenAssociateHandler', () => {
             '0.0.789012:3333333333333333333333333333333333333333333333333333333333333333',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenAssociate(args)).rejects.toThrow('Signing failed');

--- a/src/plugins/token/__tests__/unit/batch-associate.test.ts
+++ b/src/plugins/token/__tests__/unit/batch-associate.test.ts
@@ -5,7 +5,6 @@ import {
   createBatchExecuteParams,
   makeArgs,
   makeLogger,
-  makeStateMock,
 } from '@/__tests__/mocks/mocks';
 import { KeyManager } from '@/core/services/kms/kms-types.interface';
 import { SupportedNetwork } from '@/core/types/shared.types';
@@ -79,9 +78,7 @@ describe('token plugin - batch-associate hook', () => {
       addTokenAssociation: addTokenAssociationMock,
     }));
 
-    const api = {
-      state: makeStateMock(),
-    } as unknown as Partial<CoreApi>;
+    const api = {} as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
     const params = createBatchExecuteParams({
@@ -111,9 +108,7 @@ describe('token plugin - batch-associate hook', () => {
       addTokenAssociation: addTokenAssociationMock,
     }));
 
-    const api = {
-      state: makeStateMock(),
-    } as unknown as Partial<CoreApi>;
+    const api = {} as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
     const params = createBatchExecuteParams({
@@ -145,9 +140,7 @@ describe('token plugin - batch-associate hook', () => {
       addTokenAssociation: addTokenAssociationMock,
     }));
 
-    const api = {
-      state: makeStateMock(),
-    } as unknown as Partial<CoreApi>;
+    const api = {} as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
     const params = createBatchExecuteParams({
@@ -190,9 +183,7 @@ describe('token plugin - batch-associate hook', () => {
       addTokenAssociation: addTokenAssociationMock,
     }));
 
-    const api = {
-      state: makeStateMock(),
-    } as unknown as Partial<CoreApi>;
+    const api = {} as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
     const params = createBatchExecuteParams({
@@ -239,9 +230,7 @@ describe('token plugin - batch-associate hook', () => {
       addTokenAssociation: addTokenAssociationMock,
     }));
 
-    const api = {
-      state: makeStateMock(),
-    } as unknown as Partial<CoreApi>;
+    const api = {} as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
     const params = createBatchExecuteParams({
@@ -270,9 +259,7 @@ describe('token plugin - batch-associate hook', () => {
       addTokenAssociation: addTokenAssociationMock,
     }));
 
-    const api = {
-      state: makeStateMock(),
-    } as unknown as Partial<CoreApi>;
+    const api = {} as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
     const params = createBatchExecuteParams({

--- a/src/plugins/token/__tests__/unit/batch-create-ft-from-file.test.ts
+++ b/src/plugins/token/__tests__/unit/batch-create-ft-from-file.test.ts
@@ -5,7 +5,6 @@ import {
   createBatchExecuteParams,
   makeArgs,
   makeLogger,
-  makeStateMock,
 } from '@/__tests__/mocks/mocks';
 import { HederaTokenType } from '@/core';
 import { KeyManager } from '@/core/services/kms/kms-types.interface';
@@ -103,7 +102,6 @@ describe('token plugin - batch-create-ft-from-file hook', () => {
     const api = {
       receipt: { getReceipt: jest.fn() },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -135,7 +133,6 @@ describe('token plugin - batch-create-ft-from-file hook', () => {
     const api = {
       receipt: { getReceipt: jest.fn() },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -168,7 +165,6 @@ describe('token plugin - batch-create-ft-from-file hook', () => {
     const api = {
       receipt: { getReceipt: jest.fn() },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -205,7 +201,6 @@ describe('token plugin - batch-create-ft-from-file hook', () => {
     const api = {
       receipt: { getReceipt: getReceiptMock },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -246,7 +241,6 @@ describe('token plugin - batch-create-ft-from-file hook', () => {
         register: registerMock,
         exists: jest.fn().mockReturnValue(false),
       },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -321,7 +315,6 @@ describe('token plugin - batch-create-ft-from-file hook', () => {
         register: registerMock,
         exists: jest.fn().mockReturnValue(false),
       },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -394,7 +387,6 @@ describe('token plugin - batch-create-ft-from-file hook', () => {
     const api = {
       receipt: { getReceipt: getReceiptMock },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(true) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 

--- a/src/plugins/token/__tests__/unit/batch-create-ft.test.ts
+++ b/src/plugins/token/__tests__/unit/batch-create-ft.test.ts
@@ -5,7 +5,6 @@ import {
   createBatchExecuteParams,
   makeArgs,
   makeLogger,
-  makeStateMock,
 } from '@/__tests__/mocks/mocks';
 import { KeyManager } from '@/core/services/kms/kms-types.interface';
 import { HederaTokenType } from '@/core/shared/constants';
@@ -74,7 +73,6 @@ describe('token plugin - batch-create-ft hook', () => {
     const api = {
       receipt: { getReceipt: jest.fn() },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -106,7 +104,6 @@ describe('token plugin - batch-create-ft hook', () => {
     const api = {
       receipt: { getReceipt: jest.fn() },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -139,7 +136,6 @@ describe('token plugin - batch-create-ft hook', () => {
     const api = {
       receipt: { getReceipt: jest.fn() },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -174,7 +170,6 @@ describe('token plugin - batch-create-ft hook', () => {
     const api = {
       receipt: { getReceipt: getReceiptMock },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -211,7 +206,6 @@ describe('token plugin - batch-create-ft hook', () => {
     const api = {
       receipt: { getReceipt: getReceiptMock },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -289,7 +283,6 @@ describe('token plugin - batch-create-ft hook', () => {
         register: registerMock,
         exists: jest.fn().mockReturnValue(false),
       },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -370,7 +363,6 @@ describe('token plugin - batch-create-ft hook', () => {
     const api = {
       receipt: { getReceipt: getReceiptMock },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -466,7 +458,6 @@ describe('token plugin - batch-create-ft hook', () => {
     const api = {
       receipt: { getReceipt: getReceiptMock },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(true) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 

--- a/src/plugins/token/__tests__/unit/batch-create-nft-from-file.test.ts
+++ b/src/plugins/token/__tests__/unit/batch-create-nft-from-file.test.ts
@@ -5,7 +5,6 @@ import {
   createBatchExecuteParams,
   makeArgs,
   makeLogger,
-  makeStateMock,
 } from '@/__tests__/mocks/mocks';
 import { KeyManager } from '@/core/services/kms/kms-types.interface';
 import { SupplyType, SupportedNetwork } from '@/core/types/shared.types';
@@ -103,7 +102,6 @@ describe('token plugin - batch-create-nft-from-file hook', () => {
     const api = {
       receipt: { getReceipt: jest.fn() },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -135,7 +133,6 @@ describe('token plugin - batch-create-nft-from-file hook', () => {
     const api = {
       receipt: { getReceipt: jest.fn() },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -168,7 +165,6 @@ describe('token plugin - batch-create-nft-from-file hook', () => {
     const api = {
       receipt: { getReceipt: jest.fn() },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -205,7 +201,6 @@ describe('token plugin - batch-create-nft-from-file hook', () => {
     const api = {
       receipt: { getReceipt: getReceiptMock },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -246,7 +241,6 @@ describe('token plugin - batch-create-nft-from-file hook', () => {
         register: registerMock,
         exists: jest.fn().mockReturnValue(false),
       },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -314,7 +308,6 @@ describe('token plugin - batch-create-nft-from-file hook', () => {
         register: registerMock,
         exists: jest.fn().mockReturnValue(false),
       },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -375,7 +368,6 @@ describe('token plugin - batch-create-nft-from-file hook', () => {
     const api = {
       receipt: { getReceipt: getReceiptMock },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(true) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 

--- a/src/plugins/token/__tests__/unit/batch-create-nft.test.ts
+++ b/src/plugins/token/__tests__/unit/batch-create-nft.test.ts
@@ -5,7 +5,6 @@ import {
   createBatchExecuteParams,
   makeArgs,
   makeLogger,
-  makeStateMock,
 } from '@/__tests__/mocks/mocks';
 import { KeyManager } from '@/core/services/kms/kms-types.interface';
 import { HederaTokenType } from '@/core/shared/constants';
@@ -81,7 +80,6 @@ describe('token plugin - batch-create-nft hook', () => {
     const api = {
       receipt: { getReceipt: jest.fn() },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -113,7 +111,6 @@ describe('token plugin - batch-create-nft hook', () => {
     const api = {
       receipt: { getReceipt: jest.fn() },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -146,7 +143,6 @@ describe('token plugin - batch-create-nft hook', () => {
     const api = {
       receipt: { getReceipt: jest.fn() },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -181,7 +177,6 @@ describe('token plugin - batch-create-nft hook', () => {
     const api = {
       receipt: { getReceipt: getReceiptMock },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -218,7 +213,6 @@ describe('token plugin - batch-create-nft hook', () => {
     const api = {
       receipt: { getReceipt: getReceiptMock },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -308,7 +302,6 @@ describe('token plugin - batch-create-nft hook', () => {
         register: registerMock,
         exists: jest.fn().mockReturnValue(false),
       },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -397,7 +390,6 @@ describe('token plugin - batch-create-nft hook', () => {
     const api = {
       receipt: { getReceipt: getReceiptMock },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(false) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
@@ -509,7 +501,6 @@ describe('token plugin - batch-create-nft hook', () => {
     const api = {
       receipt: { getReceipt: getReceiptMock },
       alias: { register: jest.fn(), exists: jest.fn().mockReturnValue(true) },
-      state: makeStateMock(),
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 

--- a/src/plugins/token/__tests__/unit/batch-delete.test.ts
+++ b/src/plugins/token/__tests__/unit/batch-delete.test.ts
@@ -5,7 +5,6 @@ import {
   createBatchExecuteParams,
   makeArgs,
   makeLogger,
-  makeStateMock,
 } from '@/__tests__/mocks/mocks';
 import { AliasType, SupportedNetwork } from '@/core/types/shared.types';
 import { TOKEN_DELETE_COMMAND_NAME } from '@/plugins/token/commands/delete';
@@ -73,9 +72,7 @@ describe('token plugin - batch-delete hook', () => {
       removeToken: removeTokenMock,
     }));
 
-    const api = {
-      state: makeStateMock(),
-    } as unknown as Partial<CoreApi>;
+    const api = {} as unknown as Partial<CoreApi>;
     const args = makeArgs(api, makeLogger(), {});
 
     const params = createBatchExecuteParams({
@@ -102,9 +99,7 @@ describe('token plugin - batch-delete hook', () => {
     }));
 
     const logger = makeLogger();
-    const api = {
-      state: makeStateMock(),
-    } as unknown as Partial<CoreApi>;
+    const api = {} as unknown as Partial<CoreApi>;
     const args = makeArgs(api, logger, {});
 
     const params = createBatchExecuteParams({
@@ -137,7 +132,6 @@ describe('token plugin - batch-delete hook', () => {
 
     const removeAliasMock = jest.fn();
     const api = {
-      state: makeStateMock(),
       alias: {
         list: jest.fn().mockReturnValue([
           {
@@ -178,7 +172,6 @@ describe('token plugin - batch-delete hook', () => {
     }));
 
     const api = {
-      state: makeStateMock(),
       alias: { list: jest.fn().mockReturnValue([]) },
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, makeLogger(), {});
@@ -205,7 +198,6 @@ describe('token plugin - batch-delete hook', () => {
     }));
 
     const api = {
-      state: makeStateMock(),
       alias: { list: jest.fn().mockReturnValue([]) },
     } as unknown as Partial<CoreApi>;
     const args = makeArgs(api, makeLogger(), {});

--- a/src/plugins/token/__tests__/unit/cancel-airdrop.test.ts
+++ b/src/plugins/token/__tests__/unit/cancel-airdrop.test.ts
@@ -2,7 +2,6 @@ import type { CommandHandlerArgs } from '@/core/plugins/plugin.interface';
 
 import '@/core/utils/json-serialize';
 
-import { makeConfigMock, makeStateMock } from '@/__tests__/mocks/mocks';
 import { assertOutput } from '@/__tests__/utils/assert-output';
 import { TransactionError } from '@/core/errors';
 import {
@@ -11,7 +10,7 @@ import {
 } from '@/plugins/token/commands/cancel-airdrop';
 
 import { mockTransactionResults } from './helpers/fixtures';
-import { makeApiMocks, makeLogger } from './helpers/mocks';
+import { makeApiMocks } from './helpers/mocks';
 
 describe('tokenCancelAirdrop', () => {
   const mockCancelTransaction = { test: 'cancel-airdrop-transaction' };
@@ -50,9 +49,6 @@ describe('tokenCancelAirdrop', () => {
           from: '0.0.100:2222222222222222222222222222222222222222222222222222222222222222',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       const result = await tokenCancelAirdrop(args);
@@ -101,9 +97,6 @@ describe('tokenCancelAirdrop', () => {
           from: '0.0.100:2222222222222222222222222222222222222222222222222222222222222222',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       const result = await tokenCancelAirdrop(args);
@@ -141,9 +134,6 @@ describe('tokenCancelAirdrop', () => {
           receiver: '0.0.200',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       const result = await tokenCancelAirdrop(args);
@@ -182,9 +172,6 @@ describe('tokenCancelAirdrop', () => {
           receiver: '0.0.200',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       const result = await tokenCancelAirdrop(args);
@@ -225,9 +212,6 @@ describe('tokenCancelAirdrop', () => {
           receiver: 'alice',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       const result = await tokenCancelAirdrop(args);
@@ -252,9 +236,6 @@ describe('tokenCancelAirdrop', () => {
           receiver: '0.0.200',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       await expect(tokenCancelAirdrop(args)).rejects.toThrow(
@@ -273,9 +254,6 @@ describe('tokenCancelAirdrop', () => {
           receiver: 'nonexistent-alias',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       await expect(tokenCancelAirdrop(args)).rejects.toThrow(
@@ -305,9 +283,6 @@ describe('tokenCancelAirdrop', () => {
           receiver: '0.0.200',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger: makeLogger(),
       };
 
       await expect(tokenCancelAirdrop(args)).rejects.toThrow(TransactionError);

--- a/src/plugins/token/__tests__/unit/claim-airdrop.test.ts
+++ b/src/plugins/token/__tests__/unit/claim-airdrop.test.ts
@@ -16,11 +16,7 @@ import {
   TokenClaimAirdropOutputSchema,
 } from '@/plugins/token/commands/claim-airdrop';
 
-import {
-  makeApiMocks,
-  makeLogger,
-  makeTransactionResult,
-} from './helpers/mocks';
+import { makeApiMocks, makeTransactionResult } from './helpers/mocks';
 
 const SENDER_ID = '0.0.9999';
 const TOKEN_ID_FT = '0.0.2000';
@@ -102,9 +98,6 @@ const makeArgs = (
     ...args,
   },
   api,
-  state: api.state,
-  config: api.config,
-  logger: makeLogger(),
 });
 
 const makeSuccessApiMocks = (

--- a/src/plugins/token/__tests__/unit/create-nft.test.ts
+++ b/src/plugins/token/__tests__/unit/create-nft.test.ts
@@ -138,7 +138,6 @@ describe('tokenCreateNftHandler', () => {
         publicKey: '302a300506032b6570032100' + '0'.repeat(64),
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           tokenName: 'TestToken',
@@ -146,9 +145,6 @@ describe('tokenCreateNftHandler', () => {
           supplyKey: ['test-supply-key'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       // Act
@@ -208,7 +204,6 @@ describe('tokenCreateNftHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           tokenName: 'TestNFT',
@@ -224,9 +219,6 @@ describe('tokenCreateNftHandler', () => {
           metadataKey: [mockAccountKeyPairs.supply],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenCreateNft(args);
@@ -284,7 +276,6 @@ describe('tokenCreateNftHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           tokenName: 'TestNFT',
@@ -297,9 +288,6 @@ describe('tokenCreateNftHandler', () => {
           expirationTime: '2027-01-01T00:00:00Z',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenCreateNft(args);
@@ -318,7 +306,6 @@ describe('tokenCreateNftHandler', () => {
   describe('validation scenarios', () => {
     test('should reject when no supply key provided', async () => {
       const { api } = makeApiMocks();
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           tokenName: 'TestNFT',
@@ -326,9 +313,6 @@ describe('tokenCreateNftHandler', () => {
           supplyType: SupplyType.INFINITE,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenCreateNft(args)).rejects.toThrow();
@@ -336,7 +320,6 @@ describe('tokenCreateNftHandler', () => {
 
     test('should reject freezeDefault without freezeKey', async () => {
       const { api } = makeApiMocks();
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           tokenName: 'TestNFT',
@@ -346,9 +329,6 @@ describe('tokenCreateNftHandler', () => {
           freezeDefault: true,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenCreateNft(args)).rejects.toThrow(
@@ -367,7 +347,6 @@ describe('tokenCreateNftHandler', () => {
         Promise.reject(new Error('No operator set')),
       );
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           tokenName: 'TestToken',
@@ -375,9 +354,6 @@ describe('tokenCreateNftHandler', () => {
           supplyKey: ['test-supply-key'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenCreateNft(args)).rejects.toThrow('No operator set');
@@ -438,7 +414,6 @@ describe('tokenCreateNftHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           tokenName: 'TestToken',
@@ -447,16 +422,13 @@ describe('tokenCreateNftHandler', () => {
           supplyKey: ['test-supply-key'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       // Act
       await tokenCreateNft(args);
 
       // Assert
-      expect(MockedHelper).toHaveBeenCalledWith(api.state, logger);
+      expect(MockedHelper).toHaveBeenCalledWith(api.state, api.logger);
       expect(mockSaveToken).toHaveBeenCalled();
     });
   });

--- a/src/plugins/token/__tests__/unit/create.test.ts
+++ b/src/plugins/token/__tests__/unit/create.test.ts
@@ -129,16 +129,12 @@ describe('createTokenHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           tokenName: 'TestToken',
           symbol: 'TEST',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       // Act
@@ -186,16 +182,12 @@ describe('createTokenHandler', () => {
         Promise.reject(new Error('No operator set')),
       );
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           tokenName: 'TestToken',
           symbol: 'TEST',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       // Act & Assert - Error is thrown before try-catch block in handler
@@ -205,7 +197,6 @@ describe('createTokenHandler', () => {
     test('throws ValidationError when autoRenewPeriod is set without autoRenewAccount', async () => {
       const { api } = makeApiMocks();
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           tokenName: 'TestToken',
@@ -213,9 +204,6 @@ describe('createTokenHandler', () => {
           autoRenewPeriod: '30d',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenCreateFt(args)).rejects.toThrow(ValidationError);
@@ -262,7 +250,6 @@ describe('createTokenHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           tokenName: 'TestToken',
@@ -270,9 +257,6 @@ describe('createTokenHandler', () => {
           adminKey: ['test-admin-key'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       // Act & Assert
@@ -296,7 +280,6 @@ describe('createTokenHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           tokenName: 'TestToken',
@@ -304,9 +287,6 @@ describe('createTokenHandler', () => {
           adminKey: ['test-admin-key'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       // Act & Assert
@@ -314,7 +294,6 @@ describe('createTokenHandler', () => {
     });
     test('should handle initial supply limit exceeded', async () => {
       const { api } = makeApiMocks({});
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           tokenName: 'TestToken',
@@ -323,9 +302,6 @@ describe('createTokenHandler', () => {
           initialSupply: '250000000000000000000000000000',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
       await expect(tokenCreateFt(args)).rejects.toThrow(
         'Maximum balance for token exceeded. Token balance cannot be greater than 9223372036854775807',
@@ -382,7 +358,6 @@ describe('createTokenHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           tokenName: 'TestToken',
@@ -390,16 +365,13 @@ describe('createTokenHandler', () => {
           adminKey: ['test-admin-key'],
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       // Act
       await tokenCreateFt(args);
 
       // Assert
-      expect(MockedHelper).toHaveBeenCalledWith(api.state, logger);
+      expect(MockedHelper).toHaveBeenCalledWith(api.state, api.logger);
       expect(mockSaveToken).toHaveBeenCalled();
     });
   });

--- a/src/plugins/token/__tests__/unit/createFromFile.test.ts
+++ b/src/plugins/token/__tests__/unit/createFromFile.test.ts
@@ -5,7 +5,6 @@ import '@/core/utils/json-serialize';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-import { makeConfigMock, makeStateMock } from '@/__tests__/mocks/mocks';
 import { assertOutput } from '@/__tests__/utils/assert-output';
 import { FileError, StateError } from '@/core/errors';
 import { HederaTokenType } from '@/core/shared/constants';
@@ -170,15 +169,11 @@ describe('tokenCreateFtFromFileHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           file: 'test',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       // Act
@@ -221,15 +216,11 @@ describe('tokenCreateFtFromFileHandler', () => {
 
       const { api } = createMockApi();
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           file: fullPath,
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenCreateFtFromFile(args);
@@ -258,15 +249,11 @@ describe('tokenCreateFtFromFileHandler', () => {
 
       const { api } = createMockApi();
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           file: absolutePath,
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenCreateFtFromFile(args);
@@ -347,15 +334,11 @@ describe('tokenCreateFtFromFileHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           file: 'test',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       // Act
@@ -471,15 +454,11 @@ describe('tokenCreateFtFromFileHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           file: 'test',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       // Act
@@ -508,15 +487,11 @@ describe('tokenCreateFtFromFileHandler', () => {
       mockPath.resolve.mockReturnValue('/resolved/path/to/token.test.json');
 
       const { api } = makeApiMocks({});
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           file: 'nonexistent',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       // Act & Assert
@@ -530,15 +505,11 @@ describe('tokenCreateFtFromFileHandler', () => {
       mockPath.resolve.mockReturnValue('/resolved/path/to/token.test.json');
 
       const { api } = makeApiMocks({});
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           file: 'test',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       // Act & Assert
@@ -552,15 +523,11 @@ describe('tokenCreateFtFromFileHandler', () => {
       mockPath.resolve.mockReturnValue('/resolved/path/to/token.test.json');
 
       const { api } = makeApiMocks({});
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           file: 'test',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       // Act & Assert
@@ -577,15 +544,11 @@ describe('tokenCreateFtFromFileHandler', () => {
       mockPath.resolve.mockReturnValue('/resolved/path/to/token.test.json');
 
       const { api } = makeApiMocks({});
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           file: 'test',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       // Act & Assert
@@ -602,15 +565,11 @@ describe('tokenCreateFtFromFileHandler', () => {
       mockPath.resolve.mockReturnValue('/resolved/path/to/token.test.json');
 
       const { api } = makeApiMocks({});
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           file: 'test',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       // Act & Assert
@@ -627,15 +586,11 @@ describe('tokenCreateFtFromFileHandler', () => {
       mockPath.resolve.mockReturnValue('/resolved/path/to/token.test.json');
 
       const { api } = makeApiMocks({});
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           file: 'test',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       // Act & Assert
@@ -652,15 +607,11 @@ describe('tokenCreateFtFromFileHandler', () => {
       mockPath.resolve.mockReturnValue('/resolved/path/to/token.test.json');
 
       const { api } = makeApiMocks({});
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           file: 'test',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       // Act & Assert
@@ -733,15 +684,11 @@ describe('tokenCreateFtFromFileHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           file: 'test',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       // Act & Assert
@@ -815,15 +762,11 @@ describe('tokenCreateFtFromFileHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           file: 'test',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       // Act
@@ -836,7 +779,7 @@ describe('tokenCreateFtFromFileHandler', () => {
       expect(output.name).toBe('TestToken');
 
       // Should continue despite association failure
-      expect(logger.warn).toHaveBeenCalledWith(
+      expect(api.logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('⚠️  Failed to associate account 0.0.789012'),
       );
     });
@@ -856,8 +799,6 @@ describe('tokenCreateFtFromFileHandler', () => {
       mockFs.readFile.mockResolvedValue(JSON.stringify(validTokenFile));
       mockFs.access.mockResolvedValue(undefined);
       mockPath.resolve.mockReturnValue('/resolved/path/to/test.json');
-
-      const logger = makeLogger();
 
       const { api } = makeApiMocks({
         tokenTransactions: {
@@ -906,15 +847,13 @@ describe('tokenCreateFtFromFileHandler', () => {
           }),
         },
       });
+      const logger = makeLogger();
       api.logger = logger;
       const args: CommandHandlerArgs = {
         args: {
           file: 'test',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       // Act

--- a/src/plugins/token/__tests__/unit/delete-allowance-nft.test.ts
+++ b/src/plugins/token/__tests__/unit/delete-allowance-nft.test.ts
@@ -22,7 +22,6 @@ import {
 
 import {
   makeApiMocks,
-  makeLogger,
   makeTransactionResult,
   MOCK_NFT_COLLECTION_ENTITY_ID,
 } from './helpers/mocks';
@@ -86,7 +85,6 @@ describe('tokenDeleteAllowanceNft', () => {
   describe('success scenarios', () => {
     test('delete specific serials with account-id:key format', async () => {
       const { api, allowance } = makeDeleteAllowanceSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -95,9 +93,6 @@ describe('tokenDeleteAllowanceNft', () => {
           serials: '1,2,3',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenDeleteAllowanceNft(args);
@@ -125,7 +120,6 @@ describe('tokenDeleteAllowanceNft', () => {
 
     test('delete all-serials blanket approval with spender', async () => {
       const { api, allowance } = makeDeleteAllowanceSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -135,9 +129,6 @@ describe('tokenDeleteAllowanceNft', () => {
           allSerials: true,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenDeleteAllowanceNft(args);
@@ -165,7 +156,6 @@ describe('tokenDeleteAllowanceNft', () => {
     test('owner defaults to operator when not provided', async () => {
       const operatorId = MOCK_OPERATOR_ACCOUNT_ID;
       const { api, allowance } = makeDeleteAllowanceSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -173,9 +163,6 @@ describe('tokenDeleteAllowanceNft', () => {
           serials: '5',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenDeleteAllowanceNft(args);
@@ -193,7 +180,6 @@ describe('tokenDeleteAllowanceNft', () => {
 
     test('resolve token and spender by alias', async () => {
       const { api, allowance } = makeDeleteAllowanceSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -203,9 +189,6 @@ describe('tokenDeleteAllowanceNft', () => {
           allSerials: true,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenDeleteAllowanceNft(args);
@@ -229,7 +212,6 @@ describe('tokenDeleteAllowanceNft', () => {
       (api.mirror.getTokenInfo as jest.Mock).mockResolvedValue({
         type: 'FUNGIBLE_COMMON',
       });
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -237,9 +219,6 @@ describe('tokenDeleteAllowanceNft', () => {
           serials: '1',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenDeleteAllowanceNft(args)).rejects.toThrow(
@@ -250,7 +229,6 @@ describe('tokenDeleteAllowanceNft', () => {
     test('throws NotFoundError when spender account not found', async () => {
       const { api } = makeDeleteAllowanceSuccessMocks();
       (api.alias.resolve as jest.Mock).mockReturnValue(null);
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -260,9 +238,6 @@ describe('tokenDeleteAllowanceNft', () => {
           allSerials: true,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenDeleteAllowanceNft(args)).rejects.toThrow(
@@ -275,7 +250,6 @@ describe('tokenDeleteAllowanceNft', () => {
       (api.txExecute.execute as jest.Mock).mockResolvedValue(
         makeTransactionResult({ success: false, transactionId: '' }),
       );
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -284,9 +258,6 @@ describe('tokenDeleteAllowanceNft', () => {
           serials: '1',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenDeleteAllowanceNft(args)).rejects.toThrow(
@@ -296,16 +267,12 @@ describe('tokenDeleteAllowanceNft', () => {
 
     test('throws ZodError when neither serials nor all-serials specified', async () => {
       const { api } = makeDeleteAllowanceSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
           token: MOCK_HEDERA_ENTITY_ID_1,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenDeleteAllowanceNft(args)).rejects.toThrow(
@@ -315,7 +282,6 @@ describe('tokenDeleteAllowanceNft', () => {
 
     test('throws ZodError when both serials and all-serials specified', async () => {
       const { api } = makeDeleteAllowanceSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -325,9 +291,6 @@ describe('tokenDeleteAllowanceNft', () => {
           spender: MOCK_ACCOUNT_ID_ALT,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenDeleteAllowanceNft(args)).rejects.toThrow(
@@ -337,7 +300,6 @@ describe('tokenDeleteAllowanceNft', () => {
 
     test('throws ZodError when --all-serials without --spender', async () => {
       const { api } = makeDeleteAllowanceSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -345,9 +307,6 @@ describe('tokenDeleteAllowanceNft', () => {
           allSerials: true,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenDeleteAllowanceNft(args)).rejects.toThrow(
@@ -357,7 +316,6 @@ describe('tokenDeleteAllowanceNft', () => {
 
     test('throws ZodError when --spender used with --serials', async () => {
       const { api } = makeDeleteAllowanceSuccessMocks();
-      const logger = makeLogger();
 
       const args: CommandHandlerArgs = {
         args: {
@@ -366,9 +324,6 @@ describe('tokenDeleteAllowanceNft', () => {
           spender: MOCK_ACCOUNT_ID_ALT,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenDeleteAllowanceNft(args)).rejects.toThrow(

--- a/src/plugins/token/__tests__/unit/delete.test.ts
+++ b/src/plugins/token/__tests__/unit/delete.test.ts
@@ -18,7 +18,6 @@ import { ZustandTokenStateHelper } from '@/plugins/token/zustand-state-helper';
 import {
   makeDeleteApiMocks,
   makeDeleteSuccessMocks,
-  makeLogger,
   mockZustandTokenStateHelper,
 } from './helpers/mocks';
 
@@ -40,9 +39,6 @@ const makeArgs = (
     ...argsOverrides,
   },
   api,
-  state: api.state,
-  config: api.config,
-  logger: makeLogger(),
 });
 
 describe('tokenDelete - network delete (stateOnly=false)', () => {
@@ -226,9 +222,6 @@ describe('tokenDelete - state-only (stateOnly=true)', () => {
       ...argsOverrides,
     },
     api,
-    state: api.state,
-    config: api.config,
-    logger: makeLogger(),
   });
 
   test('happy path - removes token from state, returns output without transactionId', async () => {

--- a/src/plugins/token/__tests__/unit/dissociate.test.ts
+++ b/src/plugins/token/__tests__/unit/dissociate.test.ts
@@ -12,11 +12,7 @@ import {
   TokenDissociateOutputSchema,
 } from '@/plugins/token/commands/dissociate';
 
-import {
-  makeApiMocks,
-  makeLogger,
-  makeTransactionResult,
-} from './helpers/mocks';
+import { makeApiMocks, makeTransactionResult } from './helpers/mocks';
 
 describe('tokenDissociateHandler', () => {
   describe('success scenarios', () => {
@@ -46,7 +42,6 @@ describe('tokenDissociateHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: '0.0.123456',
@@ -54,9 +49,6 @@ describe('tokenDissociateHandler', () => {
             '0.0.789012:3333333333333333333333333333333333333333333333333333333333333333',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenDissociate(args);
@@ -104,16 +96,12 @@ describe('tokenDissociateHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: tokenId,
           account: `${accountId}:3333333333333333333333333333333333333333333333333333333333333333`,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenDissociate(args)).rejects.toThrow(ValidationError);
@@ -144,16 +132,12 @@ describe('tokenDissociateHandler', () => {
         txExecute: { execute: txExecuteExecute },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: tokenId,
           account: `${accountId}:3333333333333333333333333333333333333333333333333333333333333333`,
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenDissociate(args)).rejects.toThrow(ValidationError);
@@ -191,7 +175,6 @@ describe('tokenDissociateHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: '0.0.123456',
@@ -199,9 +182,6 @@ describe('tokenDissociateHandler', () => {
             '0.0.789012:3333333333333333333333333333333333333333333333333333333333333333',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenDissociate(args)).rejects.toThrow(TransactionError);
@@ -229,7 +209,6 @@ describe('tokenDissociateHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: '0.0.123456',
@@ -237,9 +216,6 @@ describe('tokenDissociateHandler', () => {
             '0.0.789012:3333333333333333333333333333333333333333333333333333333333333333',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenDissociate(args)).rejects.toThrow(

--- a/src/plugins/token/__tests__/unit/freeze.test.ts
+++ b/src/plugins/token/__tests__/unit/freeze.test.ts
@@ -13,7 +13,7 @@ import {
   TokenFreezeOutputSchema,
 } from '@/plugins/token/commands/freeze';
 
-import { makeFreezeSuccessMocks, makeLogger } from './helpers/mocks';
+import { makeFreezeSuccessMocks } from './helpers/mocks';
 
 const FREEZE_KEY_ARG = `ed25519:private:${'a'.repeat(64)}`;
 
@@ -29,9 +29,6 @@ const makeArgs = (
     ...argsOverrides,
   },
   api,
-  state: api.state,
-  config: api.config,
-  logger: makeLogger(),
 });
 
 describe('tokenFreeze', () => {

--- a/src/plugins/token/__tests__/unit/handler-output-validation.test.ts
+++ b/src/plugins/token/__tests__/unit/handler-output-validation.test.ts
@@ -22,11 +22,7 @@ import {
 } from '@/plugins/token/commands/transfer-ft';
 import { ZustandTokenStateHelper } from '@/plugins/token/zustand-state-helper';
 
-import {
-  makeApiMocks,
-  makeLogger,
-  makeTransactionResult,
-} from './helpers/mocks';
+import { makeApiMocks, makeTransactionResult } from './helpers/mocks';
 
 jest.mock('../../zustand-state-helper', () => ({
   ZustandTokenStateHelper: jest.fn(),
@@ -89,7 +85,6 @@ describe('Handler Output Validation - Token Plugin', () => {
 
       const result = await tokenCreateFt({
         api,
-        logger: makeLogger(),
         state: api.state,
         config: api.config,
         args,
@@ -157,7 +152,6 @@ describe('Handler Output Validation - Token Plugin', () => {
 
       const result = await tokenTransferFt({
         api,
-        logger: makeLogger(),
         state: api.state,
         config: api.config,
         args,
@@ -202,7 +196,6 @@ describe('Handler Output Validation - Token Plugin', () => {
 
       const result = await tokenAssociate({
         api,
-        logger: makeLogger(),
         state: api.state,
         config: api.config,
         args,
@@ -222,7 +215,6 @@ describe('Handler Output Validation - Token Plugin', () => {
 
       const result = await tokenList({
         api,
-        logger: makeLogger(),
         state: api.state,
         config: api.config,
         args,
@@ -266,7 +258,6 @@ describe('Handler Output Validation - Token Plugin', () => {
 
       const result = await tokenList({
         api,
-        logger: makeLogger(),
         state: api.state,
         config: api.config,
         args,

--- a/src/plugins/token/__tests__/unit/helpers/fixtures.ts
+++ b/src/plugins/token/__tests__/unit/helpers/fixtures.ts
@@ -495,7 +495,7 @@ export const makeTokenCreateCommandArgs = (params: {
   logger: Logger;
   args?: Record<string, string | number | boolean | undefined>;
 }) => {
-  const api = params.api as unknown as CoreApi;
+  const api = { ...params.api, logger: params.logger } as unknown as CoreApi;
   return {
     args: {
       tokenName: 'TestToken',
@@ -508,9 +508,6 @@ export const makeTokenCreateCommandArgs = (params: {
       ...params.args,
     },
     api,
-    state: api.state,
-    config: api.config,
-    logger: params.logger,
   };
 };
 
@@ -522,7 +519,7 @@ export const makeNftCreateCommandArgs = (params: {
   logger: Logger;
   args?: Record<string, unknown>;
 }) => {
-  const api = params.api as unknown as CoreApi;
+  const api = { ...params.api, logger: params.logger } as unknown as CoreApi;
   return {
     args: {
       tokenName: 'TestToken',
@@ -534,9 +531,6 @@ export const makeNftCreateCommandArgs = (params: {
       ...params.args,
     },
     api,
-    state: api.state,
-    config: api.config,
-    logger: params.logger,
   };
 };
 
@@ -882,10 +876,7 @@ export const makeMintFtCommandArgs = (params: {
       supplyKey: ['test-supply-key'],
       ...params.args,
     },
-    api: params.api,
-    state: params.api.state,
-    config: params.api.config,
-    logger: params.logger,
+    api: { ...params.api, logger: params.logger } as CoreApi,
   };
 };
 
@@ -904,10 +895,7 @@ export const makeBurnFtCommandArgs = (params: {
       supplyKey: [],
       ...params.args,
     },
-    api: params.api,
-    state: params.api.state,
-    config: params.api.config,
-    logger: params.logger,
+    api: { ...params.api, logger: params.logger } as CoreApi,
   };
 };
 
@@ -926,10 +914,7 @@ export const makeBurnNftCommandArgs = (params: {
       supplyKey: [],
       ...params.args,
     },
-    api: params.api,
-    state: params.api.state,
-    config: params.api.config,
-    logger: params.logger,
+    api: { ...params.api, logger: params.logger } as CoreApi,
   };
 };
 
@@ -956,10 +941,7 @@ export const makeTokenMintNftCommandArgs = (params: {
       supplyKey: ['test-supply-key'],
       ...params.args,
     },
-    api: params.api,
-    state: params.api.state,
-    config: params.api.config,
-    logger: params.logger,
+    api: { ...params.api, logger: params.logger } as CoreApi,
   };
 };
 
@@ -979,10 +961,7 @@ export const makeUpdateNftMetadataCommandArgs = (params: {
       metadataKey: [],
       ...params.args,
     },
-    api: params.api,
-    state: params.api.state,
-    config: params.api.config,
-    logger: params.logger,
+    api: { ...params.api, logger: params.logger } as CoreApi,
   };
 };
 
@@ -1111,16 +1090,13 @@ export const makeCreateNftFromFileCommandArgs = (params: {
   args?: Record<string, string | number | boolean | undefined>;
   hooks?: Map<HookPhase, Hook>;
 }) => {
-  const api = params.api as unknown as CoreApi;
+  const api = { ...params.api, logger: params.logger } as unknown as CoreApi;
   return {
     args: {
       file: 'test.json',
       ...params.args,
     },
     api,
-    state: api.state,
-    config: api.config,
-    logger: params.logger,
     hooks: params.hooks ?? new Map(),
   };
 };

--- a/src/plugins/token/__tests__/unit/import.test.ts
+++ b/src/plugins/token/__tests__/unit/import.test.ts
@@ -8,7 +8,6 @@ import {
   makeLogger,
   makeMirrorMock,
   makeNetworkMock,
-  makeStateMock,
 } from '@/__tests__/mocks/mocks';
 import { assertOutput } from '@/__tests__/utils/assert-output';
 import { createMockTokenInfo } from '@/core/services/mirrornode/__tests__/unit/mocks';
@@ -65,7 +64,6 @@ describe('token plugin - import command (ADR-007)', () => {
       network: networkMock as NetworkService,
       alias,
       logger,
-      state: makeStateMock(),
     };
 
     const args = makeArgs(api, logger, {
@@ -135,7 +133,6 @@ describe('token plugin - import command (ADR-007)', () => {
       network: networkMock as NetworkService,
       alias,
       logger,
-      state: makeStateMock(),
     };
 
     const args = makeArgs(api, logger, {
@@ -190,7 +187,6 @@ describe('token plugin - import command (ADR-007)', () => {
       network: makeNetworkMock(SupportedNetwork.TESTNET) as NetworkService,
       alias: makeAliasMock(),
       logger,
-      state: makeStateMock(),
     };
 
     const args = makeArgs(api, logger, {
@@ -227,7 +223,6 @@ describe('token plugin - import command (ADR-007)', () => {
       network: makeNetworkMock(SupportedNetwork.TESTNET) as NetworkService,
       alias: makeAliasMock(),
       logger,
-      state: makeStateMock(),
     };
 
     const args = makeArgs(api, logger, {
@@ -260,7 +255,6 @@ describe('token plugin - import command (ADR-007)', () => {
       network: makeNetworkMock(SupportedNetwork.TESTNET) as NetworkService,
       alias: makeAliasMock(),
       logger,
-      state: makeStateMock(),
     };
 
     const args = makeArgs(api, logger, {

--- a/src/plugins/token/__tests__/unit/list.test.ts
+++ b/src/plugins/token/__tests__/unit/list.test.ts
@@ -10,11 +10,7 @@ import {
 } from '@/plugins/token/commands/list';
 import { ZustandTokenStateHelper } from '@/plugins/token/zustand-state-helper';
 
-import {
-  makeApiMocks,
-  makeLogger,
-  setupZustandHelperMock,
-} from './helpers/mocks';
+import { makeApiMocks, setupZustandHelperMock } from './helpers/mocks';
 
 jest.mock('../../zustand-state-helper', () => ({
   ZustandTokenStateHelper: jest.fn(),
@@ -31,13 +27,9 @@ describe('tokenListHandler', () => {
     test('should return empty list when no tokens exist', async () => {
       const { api } = makeApiMocks();
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {},
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenList(args);
@@ -76,13 +68,9 @@ describe('tokenListHandler', () => {
 
       const { api } = makeApiMocks();
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {},
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenList(args);
@@ -121,13 +109,9 @@ describe('tokenListHandler', () => {
 
       const { api } = makeApiMocks();
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: { network: 'mainnet' },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenList(args);
@@ -143,18 +127,14 @@ describe('tokenListHandler', () => {
     test('should initialize token state helper', async () => {
       const { api } = makeApiMocks();
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {},
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await tokenList(args);
 
-      expect(MockedHelper).toHaveBeenCalledWith(api.state, logger);
+      expect(MockedHelper).toHaveBeenCalledWith(api.state, api.logger);
     });
   });
 });

--- a/src/plugins/token/__tests__/unit/pause.test.ts
+++ b/src/plugins/token/__tests__/unit/pause.test.ts
@@ -16,7 +16,6 @@ import {
 
 import { mockAccountIds, mockTransactionResults } from './helpers/fixtures';
 import {
-  makeLogger,
   makePauseSuccessMocks,
   MOCK_ALIAS_TOKEN_ENTITY_ID,
   MOCK_PAUSE_KEY_REF_ID,
@@ -35,9 +34,6 @@ const makeArgs = (
     ...argsOverrides,
   },
   api,
-  state: api.state,
-  config: api.config,
-  logger: makeLogger(),
 });
 
 describe('tokenPause', () => {

--- a/src/plugins/token/__tests__/unit/pending-airdrops.test.ts
+++ b/src/plugins/token/__tests__/unit/pending-airdrops.test.ts
@@ -9,7 +9,7 @@ import {
   TokenPendingAirdropsOutputSchema,
 } from '@/plugins/token/commands/pending-airdrops';
 
-import { makeApiMocks, makeLogger } from './helpers/mocks';
+import { makeApiMocks } from './helpers/mocks';
 
 const SENDER_ID = '0.0.9999';
 const TOKEN_ID_FT = '0.0.2000';
@@ -73,9 +73,6 @@ const makeArgs = (
     ...args,
   },
   api,
-  state: api.state,
-  config: api.config,
-  logger: makeLogger(),
 });
 
 describe('tokenPendingAirdrops', () => {

--- a/src/plugins/token/__tests__/unit/reject-airdrop.test.ts
+++ b/src/plugins/token/__tests__/unit/reject-airdrop.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@/plugins/token/commands/reject-airdrop';
 
 import { mockTransactionResults } from './helpers/fixtures';
-import { makeApiMocks, makeLogger } from './helpers/mocks';
+import { makeApiMocks } from './helpers/mocks';
 
 const TOKEN_ID = MOCK_HEDERA_ENTITY_ID_1;
 const MOCK_TX_ID = '0.0.123@1234567890.123456789';
@@ -65,9 +65,6 @@ const makeArgs = (
     ...args,
   },
   api,
-  state: api.state,
-  config: api.config,
-  logger: makeLogger(),
 });
 
 describe('tokenRejectAirdrop', () => {

--- a/src/plugins/token/__tests__/unit/token-lifecycle.test.ts
+++ b/src/plugins/token/__tests__/unit/token-lifecycle.test.ts
@@ -1,10 +1,7 @@
 import type { CommandHandlerArgs } from '@/core/plugins/plugin.interface';
-import type { ConfigService } from '@/core/services/config/config-service.interface';
-import type { StateService } from '@/core/services/state/state-service.interface';
 
 import '@/core/utils/json-serialize';
 
-import { makeConfigMock, makeStateMock } from '@/__tests__/mocks/mocks';
 import { FtTransferEntry } from '@/core/services/transfer';
 import { HederaTokenType } from '@/core/shared/constants';
 import { AliasType, SupplyType } from '@/core/types/shared.types';
@@ -18,11 +15,7 @@ import {
   mockKeys,
   mockTransactionResults,
 } from './helpers/fixtures';
-import {
-  makeApiMocks,
-  makeLogger,
-  mockZustandTokenStateHelper,
-} from './helpers/mocks';
+import { makeApiMocks, mockZustandTokenStateHelper } from './helpers/mocks';
 
 jest.mock('../../zustand-state-helper', () => ({
   ZustandTokenStateHelper: jest.fn(),
@@ -103,8 +96,6 @@ describe('Token Lifecycle Integration', () => {
         },
       });
 
-      const logger = makeLogger();
-
       // Step 1: Create Token
       const createArgs: CommandHandlerArgs = {
         args: {
@@ -118,9 +109,6 @@ describe('Token Lifecycle Integration', () => {
           adminKey: ['admin-key'],
         },
         api,
-        logger,
-        state: makeStateMock() as StateService,
-        config: makeConfigMock() as ConfigService,
       };
 
       const createResult = await tokenCreateFt(createArgs);
@@ -133,9 +121,6 @@ describe('Token Lifecycle Integration', () => {
           account: `${userAccountId}:${userKey}`,
         },
         api,
-        logger,
-        state: makeStateMock() as StateService,
-        config: makeConfigMock() as ConfigService,
       };
 
       const associateResult = await tokenAssociate(associateArgs);
@@ -150,9 +135,6 @@ describe('Token Lifecycle Integration', () => {
           amount: '100',
         },
         api,
-        logger,
-        state: makeStateMock() as StateService,
-        config: makeConfigMock() as ConfigService,
       };
 
       const transferResult = await tokenTransferFt(transferArgs);
@@ -260,8 +242,6 @@ describe('Token Lifecycle Integration', () => {
         },
       });
 
-      const logger = makeLogger();
-
       // Step 1: Create Token (success)
       const createArgs: CommandHandlerArgs = {
         args: {
@@ -271,9 +251,6 @@ describe('Token Lifecycle Integration', () => {
           adminKey: ['admin-key'],
         },
         api,
-        logger,
-        state: makeStateMock() as StateService,
-        config: makeConfigMock() as ConfigService,
       };
 
       const createResult = await tokenCreateFt(createArgs);
@@ -286,9 +263,6 @@ describe('Token Lifecycle Integration', () => {
           account: `${userAccountId}:${userKey}`,
         },
         api,
-        logger,
-        state: makeStateMock() as StateService,
-        config: makeConfigMock() as ConfigService,
       };
 
       const associateResult = await tokenAssociate(associateArgs);
@@ -365,8 +339,6 @@ describe('Token Lifecycle Integration', () => {
         },
       });
 
-      const logger = makeLogger();
-
       // Step 1: Create Token
       const createArgs: CommandHandlerArgs = {
         args: {
@@ -376,9 +348,6 @@ describe('Token Lifecycle Integration', () => {
           adminKey: ['admin-key'],
         },
         api,
-        logger,
-        state: makeStateMock() as StateService,
-        config: makeConfigMock() as ConfigService,
       };
 
       const createResult = await tokenCreateFt(createArgs);
@@ -391,9 +360,6 @@ describe('Token Lifecycle Integration', () => {
           account: `${userAccountId1}:${userKey1}`,
         },
         api,
-        logger,
-        state: makeStateMock() as StateService,
-        config: makeConfigMock() as ConfigService,
       };
 
       const associateResult1 = await tokenAssociate(associateArgs1);
@@ -406,9 +372,6 @@ describe('Token Lifecycle Integration', () => {
           account: `${userAccountId2}:${userKey2}`,
         },
         api,
-        logger,
-        state: makeStateMock() as StateService,
-        config: makeConfigMock() as ConfigService,
       };
 
       const associateResult2 = await tokenAssociate(associateArgs2);
@@ -452,8 +415,6 @@ describe('Token Lifecycle Integration', () => {
         },
       });
 
-      const logger = makeLogger();
-
       // Create token - this will throw because execute returns no tokenId
       const createArgs: CommandHandlerArgs = {
         args: {
@@ -463,9 +424,6 @@ describe('Token Lifecycle Integration', () => {
           adminKey: ['admin-key'],
         },
         api,
-        logger,
-        state: makeStateMock() as StateService,
-        config: makeConfigMock() as ConfigService,
       };
 
       await expect(tokenCreateFt(createArgs)).rejects.toThrow();
@@ -476,15 +434,12 @@ describe('Token Lifecycle Integration', () => {
           account: `${userAccountId}:5555555555555555555555555555555555555555555555555555555555555555`,
         },
         api,
-        logger,
-        state: makeStateMock() as StateService,
-        config: makeConfigMock() as ConfigService,
       };
 
       const associateResult = await tokenAssociate(associateArgs);
       expect(associateResult.result).toBeDefined();
 
-      expect(MockedHelper).toHaveBeenCalledWith(api.state, logger);
+      expect(MockedHelper).toHaveBeenCalledWith(api.state, api.logger);
     });
   });
 });

--- a/src/plugins/token/__tests__/unit/transfer.test.ts
+++ b/src/plugins/token/__tests__/unit/transfer.test.ts
@@ -4,7 +4,6 @@ import type { NetworkService } from '@/core/services/network/network-service.int
 import '@/core/utils/json-serialize';
 
 import { ECDSA_HEX_PRIVATE_KEY } from '@/__tests__/mocks/fixtures';
-import { makeConfigMock, makeStateMock } from '@/__tests__/mocks/mocks';
 import { assertOutput } from '@/__tests__/utils/assert-output';
 import { NetworkError, SupportedNetwork } from '@/core';
 import { FtTransferEntry } from '@/core/services/transfer';
@@ -16,7 +15,7 @@ import {
 } from '@/plugins/token/commands/transfer-ft';
 
 import { mockAccountIds, mockTransactionResults } from './helpers/fixtures';
-import { makeApiMocks, makeLogger } from './helpers/mocks';
+import { makeApiMocks } from './helpers/mocks';
 
 const FROM_ACCOUNT = `${mockAccountIds.sender}:${ECDSA_HEX_PRIVATE_KEY}`;
 
@@ -52,7 +51,6 @@ describe('transferTokenHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: mockAccountIds.treasury,
@@ -61,9 +59,6 @@ describe('transferTokenHandler', () => {
           amount: '100',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenTransferFt(args);
@@ -126,7 +121,6 @@ describe('transferTokenHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: mockAccountIds.treasury,
@@ -135,9 +129,6 @@ describe('transferTokenHandler', () => {
           amount: '100',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenTransferFt(args);
@@ -203,7 +194,6 @@ describe('transferTokenHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: mockAccountIds.treasury,
@@ -212,9 +202,6 @@ describe('transferTokenHandler', () => {
           amount: '100',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenTransferFt(args);
@@ -245,7 +232,6 @@ describe('transferTokenHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: mockAccountIds.treasury,
@@ -254,9 +240,6 @@ describe('transferTokenHandler', () => {
           amount: '0',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenTransferFt(args);
@@ -307,7 +290,6 @@ describe('transferTokenHandler', () => {
         }),
       } as NetworkService;
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: mockAccountIds.treasury,
@@ -315,9 +297,6 @@ describe('transferTokenHandler', () => {
           amount: '100',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenTransferFt(args);
@@ -353,7 +332,6 @@ describe('transferTokenHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: mockAccountIds.treasury,
@@ -362,9 +340,6 @@ describe('transferTokenHandler', () => {
           amount: '100',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       await expect(tokenTransferFt(args)).rejects.toThrow();
@@ -385,7 +360,6 @@ describe('transferTokenHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: mockAccountIds.treasury,
@@ -394,9 +368,6 @@ describe('transferTokenHandler', () => {
           amount: '100',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       await expect(tokenTransferFt(args)).rejects.toThrow('Network error');
@@ -425,7 +396,6 @@ describe('transferTokenHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: mockAccountIds.treasury,
@@ -434,9 +404,6 @@ describe('transferTokenHandler', () => {
           amount: '100',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       await expect(tokenTransferFt(args)).rejects.toThrow('Invalid key');
@@ -469,7 +436,6 @@ describe('transferTokenHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: mockAccountIds.treasury,
@@ -478,9 +444,6 @@ describe('transferTokenHandler', () => {
           amount: '999999999',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenTransferFt(args);
@@ -528,7 +491,6 @@ describe('transferTokenHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: mockAccountIds.treasury,
@@ -537,9 +499,6 @@ describe('transferTokenHandler', () => {
           amount: '100',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenTransferFt(args);
@@ -578,7 +537,6 @@ describe('transferTokenHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: mockAccountIds.treasury,
@@ -587,9 +545,6 @@ describe('transferTokenHandler', () => {
           amount: '100',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenTransferFt(args);
@@ -610,7 +565,6 @@ describe('transferTokenHandler', () => {
 
     test('should handle decimal amounts', async () => {
       const { api } = makeApiMocks({});
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: mockAccountIds.treasury,
@@ -619,9 +573,6 @@ describe('transferTokenHandler', () => {
           amount: '100.5',
         },
         api,
-        state: makeStateMock(),
-        config: makeConfigMock(),
-        logger,
       };
 
       const result = await tokenTransferFt(args);

--- a/src/plugins/token/__tests__/unit/unfreeze.test.ts
+++ b/src/plugins/token/__tests__/unit/unfreeze.test.ts
@@ -13,7 +13,7 @@ import {
   TokenUnfreezeOutputSchema,
 } from '@/plugins/token/commands/unfreeze';
 
-import { makeLogger, makeUnfreezeSuccessMocks } from './helpers/mocks';
+import { makeUnfreezeSuccessMocks } from './helpers/mocks';
 
 const FREEZE_KEY_ARG = `ed25519:private:${'a'.repeat(64)}`;
 
@@ -29,9 +29,6 @@ const makeArgs = (
     ...argsOverrides,
   },
   api,
-  state: api.state,
-  config: api.config,
-  logger: makeLogger(),
 });
 
 describe('tokenUnfreeze', () => {

--- a/src/plugins/token/__tests__/unit/unpause.test.ts
+++ b/src/plugins/token/__tests__/unit/unpause.test.ts
@@ -16,7 +16,6 @@ import {
 
 import { mockAccountIds, mockTransactionResults } from './helpers/fixtures';
 import {
-  makeLogger,
   makeUnpauseSuccessMocks,
   MOCK_ALIAS_TOKEN_ENTITY_ID,
   MOCK_PAUSE_KEY_REF_ID,
@@ -35,9 +34,6 @@ const makeArgs = (
     ...argsOverrides,
   },
   api,
-  state: api.state,
-  config: api.config,
-  logger: makeLogger(),
 });
 
 describe('tokenUnpause', () => {

--- a/src/plugins/token/__tests__/unit/update.test.ts
+++ b/src/plugins/token/__tests__/unit/update.test.ts
@@ -18,11 +18,7 @@ import {
 import { TokenUpdateOutputSchema } from '@/plugins/token/commands/update/output';
 import { ZustandTokenStateHelper } from '@/plugins/token/zustand-state-helper';
 
-import {
-  makeApiMocks,
-  makeLogger,
-  makeTransactionResult,
-} from './helpers/mocks';
+import { makeApiMocks, makeTransactionResult } from './helpers/mocks';
 
 jest.mock('@/plugins/token/zustand-state-helper');
 
@@ -95,9 +91,6 @@ const makeArgs = (
     ...argsOverrides,
   },
   api,
-  state: api.state,
-  config: api.config,
-  logger: makeLogger(),
 });
 
 describe('tokenUpdate', () => {

--- a/src/plugins/token/__tests__/unit/view.test.ts
+++ b/src/plugins/token/__tests__/unit/view.test.ts
@@ -16,11 +16,7 @@ import {
 } from '@/plugins/token/commands/view';
 import { ZustandTokenStateHelper } from '@/plugins/token/zustand-state-helper';
 
-import {
-  makeApiMocks,
-  makeLogger,
-  mockZustandTokenStateHelper,
-} from './helpers/mocks';
+import { makeApiMocks, mockZustandTokenStateHelper } from './helpers/mocks';
 
 jest.mock('../../zustand-state-helper', () => ({
   ZustandTokenStateHelper: jest.fn(),
@@ -63,15 +59,11 @@ describe('tokenViewHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: '0.0.123456',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenView(args);
@@ -119,13 +111,9 @@ describe('tokenViewHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: { token: '0.0.123456' },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenView(args);
@@ -164,15 +152,11 @@ describe('tokenViewHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: 'my-token',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       const result = await tokenView(args);
@@ -201,15 +185,11 @@ describe('tokenViewHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: '0.0.999999',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenView(args)).rejects.toThrow();
@@ -225,15 +205,11 @@ describe('tokenViewHandler', () => {
         },
       });
 
-      const logger = makeLogger();
       const args: CommandHandlerArgs = {
         args: {
           token: '0.0.123456',
         },
         api,
-        state: api.state,
-        config: api.config,
-        logger,
       };
 
       await expect(tokenView(args)).rejects.toThrow('API Error');

--- a/src/plugins/token/commands/airdrop-ft/handler.ts
+++ b/src/plugins/token/commands/airdrop-ft/handler.ts
@@ -39,9 +39,9 @@ export class TokenAirdropFtCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TokenAirdropFtNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const validArgs = TokenAirdropFtInputSchema.parse(args.args);
 
     const {
@@ -121,8 +121,8 @@ export class TokenAirdropFtCommand extends BaseTransactionCommand<
     const { accountId: fromAccountId, keyRefId: signerKeyRefId } =
       resolvedFromAccount;
 
-    logger.info(`🔑 Using from account: ${fromAccountId}`);
-    logger.info(
+    api.logger.info(`🔑 Using from account: ${fromAccountId}`);
+    api.logger.info(
       `Airdropping ${tokenId} to ${resolvedRecipients.length} recipient(s)`,
     );
 
@@ -140,8 +140,8 @@ export class TokenAirdropFtCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: TokenAirdropFtNormalizedParams,
   ): Promise<TokenAirdropFtBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building airdrop transaction body');
+    const { api } = args;
+    api.logger.debug('Building airdrop transaction body');
 
     const transaction = api.token.createAirdropFtTransaction({
       tokenId: normalisedParams.tokenId,
@@ -160,8 +160,10 @@ export class TokenAirdropFtCommand extends BaseTransactionCommand<
     normalisedParams: TokenAirdropFtNormalizedParams,
     buildTransactionResult: TokenAirdropFtBuildTransactionResult,
   ): Promise<TokenAirdropFtSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(`Using key ${normalisedParams.signerKeyRefId} for signing`);
+    const { api } = args;
+    api.logger.debug(
+      `Using key ${normalisedParams.signerKeyRefId} for signing`,
+    );
 
     const transaction = await api.txSign.sign(
       buildTransactionResult.transaction,

--- a/src/plugins/token/commands/airdrop-nft/handler.ts
+++ b/src/plugins/token/commands/airdrop-nft/handler.ts
@@ -41,7 +41,7 @@ export class TokenAirdropNftCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TokenAirdropNftNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TokenAirdropNftInputSchema.parse(args.args);
 
     const {
@@ -117,8 +117,8 @@ export class TokenAirdropNftCommand extends BaseTransactionCommand<
     const { accountId: fromAccountId, keyRefId: signerKeyRefId } =
       resolvedFromAccount;
 
-    logger.info(`🔑 Using from account: ${fromAccountId}`);
-    logger.info(
+    api.logger.info(`🔑 Using from account: ${fromAccountId}`);
+    api.logger.info(
       `Airdropping NFT ${tokenId} to ${recipients.length} recipient(s)`,
     );
 
@@ -136,8 +136,8 @@ export class TokenAirdropNftCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: TokenAirdropNftNormalizedParams,
   ): Promise<TokenAirdropNftBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building NFT airdrop transaction body');
+    const { api } = args;
+    api.logger.debug('Building NFT airdrop transaction body');
     const transaction = api.token.createAirdropNftTransaction({
       tokenId: normalisedParams.tokenId,
       senderAccountId: normalisedParams.fromAccountId,
@@ -154,8 +154,10 @@ export class TokenAirdropNftCommand extends BaseTransactionCommand<
     normalisedParams: TokenAirdropNftNormalizedParams,
     buildTransactionResult: TokenAirdropNftBuildTransactionResult,
   ): Promise<TokenAirdropNftSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(`Using key ${normalisedParams.signerKeyRefId} for signing`);
+    const { api } = args;
+    api.logger.debug(
+      `Using key ${normalisedParams.signerKeyRefId} for signing`,
+    );
     const transaction = await api.txSign.sign(
       buildTransactionResult.transaction,
       [normalisedParams.signerKeyRefId],

--- a/src/plugins/token/commands/allowance-ft/handler.ts
+++ b/src/plugins/token/commands/allowance-ft/handler.ts
@@ -37,7 +37,7 @@ export class TokenAllowanceFtCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TokenAllowanceFtNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TokenAllowanceFtInputSchema.parse(args.args);
 
     const keyManager =
@@ -54,7 +54,7 @@ export class TokenAllowanceFtCommand extends BaseTransactionCommand<
     }
     const tokenId = resolvedToken.tokenId;
 
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     let tokenDecimals = 0;
     if (!isRawUnits(validArgs.amount)) {
       const tokenInfoStorage = tokenState.getToken(tokenId);
@@ -89,7 +89,7 @@ export class TokenAllowanceFtCommand extends BaseTransactionCommand<
       );
     }
 
-    logger.info(
+    api.logger.info(
       `Approving ${rawAmount.toString()} tokens of ${tokenId} for spender ${resolvedSpender.accountId}`,
     );
 

--- a/src/plugins/token/commands/allowance-nft/handler.ts
+++ b/src/plugins/token/commands/allowance-nft/handler.ts
@@ -39,7 +39,7 @@ export class TokenAllowanceNftCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<AllowanceNftNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TokenAllowanceNftInputSchema.parse(args.args);
     const keyManager =
       validArgs.keyManager ??
@@ -82,9 +82,9 @@ export class TokenAllowanceNftCommand extends BaseTransactionCommand<
       );
     }
 
-    logger.info(`🔑 Using owner account: ${resolvedOwner.accountId}`);
-    logger.info(`🔑 Approving spender: ${resolvedSpender.accountId}`);
-    logger.info(
+    api.logger.info(`🔑 Using owner account: ${resolvedOwner.accountId}`);
+    api.logger.info(`🔑 Approving spender: ${resolvedSpender.accountId}`);
+    api.logger.info(
       validArgs.allSerials
         ? `Approving all serials of ${tokenId} for ${resolvedSpender.accountId}`
         : `Approving serials [${validArgs.serials?.join(', ')}] of ${tokenId} for ${resolvedSpender.accountId}`,
@@ -126,8 +126,8 @@ export class TokenAllowanceNftCommand extends BaseTransactionCommand<
     normalisedParams: AllowanceNftNormalizedParams,
     buildTransactionResult: AllowanceNftBuildTransactionResult,
   ): Promise<AllowanceNftSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using key ${normalisedParams.signerKeyRefId} for signing transaction`,
     );
     const signedTransaction = await api.txSign.sign(

--- a/src/plugins/token/commands/associate/handler.ts
+++ b/src/plugins/token/commands/associate/handler.ts
@@ -34,7 +34,7 @@ export class TokenAssociateCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<AssociateNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TokenAssociateInputSchema.parse(args.args);
     const keyManager =
       validArgs.keyManager ??
@@ -56,9 +56,9 @@ export class TokenAssociateCommand extends BaseTransactionCommand<
       ['token:associate'],
     );
 
-    logger.info(`🔑 Using account: ${account.accountId}`);
-    logger.info('🔑 Will sign with account key');
-    logger.info(
+    api.logger.info(`🔑 Using account: ${account.accountId}`);
+    api.logger.info('🔑 Will sign with account key');
+    api.logger.info(
       `Associating token ${tokenId} with account ${account.accountId}`,
     );
 
@@ -102,8 +102,8 @@ export class TokenAssociateCommand extends BaseTransactionCommand<
     normalisedParams: AssociateNormalizedParams,
     buildTransactionResult: AssociateBuildTransactionResult,
   ): Promise<AssociateSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using key ${normalisedParams.account.keyRefId} for signing transaction`,
     );
     const signedTransaction = await api.txSign.sign(

--- a/src/plugins/token/commands/burn-ft/handler.ts
+++ b/src/plugins/token/commands/burn-ft/handler.ts
@@ -39,9 +39,9 @@ export class TokenBurnFtCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<BurnFtNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
 
     const validArgs = TokenBurnFtInputSchema.parse(args.args);
 
@@ -65,7 +65,7 @@ export class TokenBurnFtCommand extends BaseTransactionCommand<
 
     const tokenId = resolvedToken.tokenId;
 
-    logger.info(`Burning tokens for token: ${tokenId}`);
+    api.logger.info(`Burning tokens for token: ${tokenId}`);
 
     const tokenInfo = await api.mirror.getTokenInfo(tokenId);
 
@@ -110,7 +110,7 @@ export class TokenBurnFtCommand extends BaseTransactionCommand<
       });
     }
 
-    logger.info(
+    api.logger.info(
       `Burning ${rawAmount.toString()} tokens. Current supply: ${currentTotalSupply.toString()}, after burn: ${(currentTotalSupply - rawAmount).toString()}`,
     );
 
@@ -127,8 +127,8 @@ export class TokenBurnFtCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: BurnFtNormalizedParams,
   ): Promise<BurnFtBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building burn transaction body');
+    const { api } = args;
+    api.logger.debug('Building burn transaction body');
     const transaction = api.token.createBurnFtTransaction({
       tokenId: normalisedParams.tokenId,
       amount: normalisedParams.rawAmount,
@@ -141,8 +141,8 @@ export class TokenBurnFtCommand extends BaseTransactionCommand<
     normalisedParams: BurnFtNormalizedParams,
     buildTransactionResult: BurnFtBuildTransactionResult,
   ): Promise<BurnFtSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using ${normalisedParams.keyRefIds.length} key(s) for signing transaction`,
     );
     const transaction = await api.txSign.sign(

--- a/src/plugins/token/commands/burn-nft/handler.ts
+++ b/src/plugins/token/commands/burn-nft/handler.ts
@@ -37,9 +37,9 @@ export class TokenBurnNftCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<BurnNftNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
 
     const validArgs = TokenBurnNftInputSchema.parse(args.args);
 
@@ -62,7 +62,7 @@ export class TokenBurnNftCommand extends BaseTransactionCommand<
 
     const tokenId = resolvedToken.tokenId;
 
-    logger.info(`Burning NFT serials for token: ${tokenId}`);
+    api.logger.info(`Burning NFT serials for token: ${tokenId}`);
 
     const tokenInfo = await api.mirror.getTokenInfo(tokenId);
 
@@ -94,7 +94,7 @@ export class TokenBurnNftCommand extends BaseTransactionCommand<
     const serialNumbers = validArgs.serials;
     const currentTotalSupply = BigInt(tokenInfo.total_supply || '0');
 
-    logger.info(
+    api.logger.info(
       `Burning ${serialNumbers.length} NFT serial(s). Current supply: ${currentTotalSupply.toString()}, after burn: ${(currentTotalSupply - BigInt(serialNumbers.length)).toString()}`,
     );
 
@@ -111,8 +111,8 @@ export class TokenBurnNftCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: BurnNftNormalizedParams,
   ): Promise<BurnNftBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building NFT burn transaction body');
+    const { api } = args;
+    api.logger.debug('Building NFT burn transaction body');
     const transaction = api.token.createBurnNftTransaction({
       tokenId: normalisedParams.tokenId,
       serialNumbers: normalisedParams.serialNumbers,
@@ -125,8 +125,8 @@ export class TokenBurnNftCommand extends BaseTransactionCommand<
     normalisedParams: BurnNftNormalizedParams,
     buildTransactionResult: BurnNftBuildTransactionResult,
   ): Promise<BurnNftSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using ${normalisedParams.keyRefIds.length} key(s) for signing transaction`,
     );
     const transaction = await api.txSign.sign(

--- a/src/plugins/token/commands/cancel-airdrop/handler.ts
+++ b/src/plugins/token/commands/cancel-airdrop/handler.ts
@@ -33,7 +33,7 @@ export class TokenCancelAirdropCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<CancelAirdropNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = TokenCancelAirdropInputSchema.parse(args.args);
     const {
@@ -83,7 +83,7 @@ export class TokenCancelAirdropCommand extends BaseTransactionCommand<
     const { accountId: senderAccountId, keyRefId: signerKeyRefId } =
       resolvedFrom;
 
-    logger.info(
+    api.logger.info(
       `Cancelling airdrop: ${tokenId}${serial !== undefined ? `#${serial}` : ''} from ${senderAccountId} to ${receiverAccountId}`,
     );
 
@@ -102,8 +102,8 @@ export class TokenCancelAirdropCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: CancelAirdropNormalizedParams,
   ): Promise<CancelAirdropBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building cancel airdrop transaction body');
+    const { api } = args;
+    api.logger.debug('Building cancel airdrop transaction body');
 
     const transaction = api.token.createCancelAirdropTransaction({
       senderAccountId: normalisedParams.senderAccountId,
@@ -122,8 +122,10 @@ export class TokenCancelAirdropCommand extends BaseTransactionCommand<
     normalisedParams: CancelAirdropNormalizedParams,
     buildTransactionResult: CancelAirdropBuildTransactionResult,
   ): Promise<CancelAirdropSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(`Using key ${normalisedParams.signerKeyRefId} for signing`);
+    const { api } = args;
+    api.logger.debug(
+      `Using key ${normalisedParams.signerKeyRefId} for signing`,
+    );
 
     const transaction = await api.txSign.sign(
       buildTransactionResult.transaction,

--- a/src/plugins/token/commands/claim-airdrop/handler.ts
+++ b/src/plugins/token/commands/claim-airdrop/handler.ts
@@ -37,7 +37,7 @@ export class TokenClaimAirdropCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TokenClaimAirdropNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TokenClaimAirdropInputSchema.parse(args.args);
 
     const network = api.network.getCurrentNetwork();
@@ -48,7 +48,7 @@ export class TokenClaimAirdropCommand extends BaseTransactionCommand<
         network,
       });
 
-    logger.info(`Fetching pending airdrops for ${receiverAccountId}...`);
+    api.logger.info(`Fetching pending airdrops for ${receiverAccountId}...`);
     const response = await api.mirror.getPendingAirdrops(receiverAccountId);
     const allAirdrops = response.airdrops;
 
@@ -61,7 +61,7 @@ export class TokenClaimAirdropCommand extends BaseTransactionCommand<
     ];
     const tokenInfoMap = await this.fetchTokenInfoMap(
       api.mirror,
-      logger,
+      api.logger,
       uniqueTokenIds,
     );
 
@@ -93,7 +93,7 @@ export class TokenClaimAirdropCommand extends BaseTransactionCommand<
       throw new ValidationError(`Failed to resolve signing account for claim`);
     }
 
-    logger.info(
+    api.logger.info(
       `Claiming ${claimItems.length} airdrop(s) for ${receiverAccountId}`,
     );
 
@@ -111,8 +111,8 @@ export class TokenClaimAirdropCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalizedParams: TokenClaimAirdropNormalizedParams,
   ): Promise<TokenClaimAirdropBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building claim airdrop transaction body');
+    const { api } = args;
+    api.logger.debug('Building claim airdrop transaction body');
 
     const transaction = api.token.createClaimAirdropTransaction({
       items: normalizedParams.claimItems,
@@ -126,8 +126,10 @@ export class TokenClaimAirdropCommand extends BaseTransactionCommand<
     normalizedParams: TokenClaimAirdropNormalizedParams,
     buildResult: TokenClaimAirdropBuildTransactionResult,
   ): Promise<TokenClaimAirdropSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(`Using key ${normalizedParams.signerKeyRefId} for signing`);
+    const { api } = args;
+    api.logger.debug(
+      `Using key ${normalizedParams.signerKeyRefId} for signing`,
+    );
 
     const signedTransaction = await api.txSign.sign(buildResult.transaction, [
       normalizedParams.signerKeyRefId,

--- a/src/plugins/token/commands/create-ft-from-file/handler.ts
+++ b/src/plugins/token/commands/create-ft-from-file/handler.ts
@@ -45,17 +45,17 @@ export class TokenCreateFtFromFileCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TokenCreateFtFromFileNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TokenCreateFtFromFileInputSchema.parse(args.args);
     const keyManager =
       validArgs.keyManager ??
       api.config.getOption<KeyManager>(ConfigOptionKey.default_key_manager);
 
-    logger.info(`Creating fungible token from file: ${validArgs.file}`);
+    api.logger.info(`Creating fungible token from file: ${validArgs.file}`);
 
     const tokenDefinition = await readAndValidateTokenFile(
       validArgs.file,
-      logger,
+      api.logger,
     );
     const network = api.network.getCurrentNetwork();
     api.alias.availableOrThrow(tokenDefinition.name, network);
@@ -100,7 +100,7 @@ export class TokenCreateFtFromFileCommand extends BaseTransactionCommand<
       autoRenewAccountCredential !== undefined
     ) {
       if (expirationTime !== undefined) {
-        logger.warn(
+        api.logger.warn(
           'expirationTime is ignored because autoRenewPeriod is set; auto-renew period takes precedence over fixed expiration.',
         );
       }
@@ -213,12 +213,12 @@ export class TokenCreateFtFromFileCommand extends BaseTransactionCommand<
     normalisedParams: TokenCreateFtFromFileNormalizedParams,
     buildTransactionResult: TokenCreateFtFromFileBuildTransactionResult,
   ): Promise<TokenCreateFtFromFileSignTransactionResult> {
-    const { api, logger } = args;
+    const { api } = args;
     const signingKeys = [
       normalisedParams.treasury.keyRefId,
       ...normalisedParams.adminKeys.map((k) => k.keyRefId),
     ];
-    logger.info(
+    api.logger.info(
       `🔑 Signing token create with treasury${normalisedParams.adminKeys.length > 0 ? ' and admin' : ''} (${signingKeys.length} key(s))`,
     );
     const transaction = await api.txSign.sign(
@@ -258,8 +258,8 @@ export class TokenCreateFtFromFileCommand extends BaseTransactionCommand<
     _signTransactionResult: TokenCreateFtFromFileSignTransactionResult,
     executeTransactionResult: TokenCreateFtFromFileExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const { api } = args;
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const result = executeTransactionResult.transactionResult;
     const tokenData = buildTokenDataFromFile(result, normalisedParams);
 
@@ -268,14 +268,14 @@ export class TokenCreateFtFromFileCommand extends BaseTransactionCommand<
       tokenId,
       normalisedParams.associations,
       api,
-      logger,
+      api.logger,
       normalisedParams.keyManager,
     );
     tokenData.associations = successfulAssociations;
 
     const key = composeKey(normalisedParams.network, tokenId);
     tokenState.saveToken(key, tokenData);
-    logger.info('   Token data saved to state');
+    api.logger.info('   Token data saved to state');
 
     if (normalisedParams.alias && result.tokenId) {
       api.alias.register({
@@ -285,7 +285,7 @@ export class TokenCreateFtFromFileCommand extends BaseTransactionCommand<
         entityId: tokenId,
         createdAt: result.consensusTimestamp,
       });
-      logger.info(`   Name registered: ${normalisedParams.alias}`);
+      api.logger.info(`   Name registered: ${normalisedParams.alias}`);
     }
 
     const associations: TokenCreateFtFromFileAssociationOutput[] =

--- a/src/plugins/token/commands/create-ft-from-file/handler.ts
+++ b/src/plugins/token/commands/create-ft-from-file/handler.ts
@@ -268,7 +268,6 @@ export class TokenCreateFtFromFileCommand extends BaseTransactionCommand<
       tokenId,
       normalisedParams.associations,
       api,
-      api.logger,
       normalisedParams.keyManager,
     );
     tokenData.associations = successfulAssociations;

--- a/src/plugins/token/commands/create-ft/handler.ts
+++ b/src/plugins/token/commands/create-ft/handler.ts
@@ -45,7 +45,7 @@ export class TokenCreateFtCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TokenCreateFtNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs: TokenCreateFtInput = TokenCreateFtInputSchema.parse(
       args.args,
     );
@@ -103,7 +103,7 @@ export class TokenCreateFtCommand extends BaseTransactionCommand<
       autoRenewAccountCredential !== undefined
     ) {
       if (expirationTime) {
-        logger.warn(
+        api.logger.warn(
           'Expiration time is ignored because auto-renew period is set; auto-renew period takes precedence over fixed expiration.',
         );
       }
@@ -114,25 +114,25 @@ export class TokenCreateFtCommand extends BaseTransactionCommand<
     if (validArgs.supplyType === SupplyType.FINITE) {
       finalMaxSupply = determineFiniteMaxSupply(maxSupply, initialSupply);
     } else if (maxSupply !== undefined) {
-      logger.warn(
+      api.logger.warn(
         'Max supply specified for INFINITE supply type - ignoring max supply parameter',
       );
     }
 
-    logger.info(
+    api.logger.info(
       `Creating fungible token: ${validArgs.tokenName} (${validArgs.symbol})`,
     );
     if (finalMaxSupply !== undefined) {
-      logger.info(`Max supply: ${finalMaxSupply}`);
+      api.logger.info(`Max supply: ${finalMaxSupply}`);
     }
 
-    logger.debug('=== TOKEN PARAMS DEBUG ===');
-    logger.debug(`Treasury ID: ${treasury.keyRefId}`);
-    logger.debug(
+    api.logger.debug('=== TOKEN PARAMS DEBUG ===');
+    api.logger.debug(`Treasury ID: ${treasury.keyRefId}`);
+    api.logger.debug(
       `Admin Keys (keyRefIds): ${admin.map((k) => k.keyRefId).join(', ')}`,
     );
-    logger.debug(`Use Custom Treasury: ${String(Boolean(treasury))}`);
-    logger.debug('=========================');
+    api.logger.debug(`Use Custom Treasury: ${String(Boolean(treasury))}`);
+    api.logger.debug('=========================');
 
     return {
       name: validArgs.tokenName,
@@ -281,8 +281,8 @@ export class TokenCreateFtCommand extends BaseTransactionCommand<
     _signTransactionResult: TokenCreateFtSignTransactionResult,
     executeTransactionResult: TokenCreateFtExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const { api } = args;
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const result = executeTransactionResult.transactionResult;
 
     const tokenData = buildTokenData(result, {
@@ -317,7 +317,7 @@ export class TokenCreateFtCommand extends BaseTransactionCommand<
     const tokenId = result.tokenId ?? '';
     const key = composeKey(normalisedParams.network, tokenId);
     tokenState.saveToken(key, tokenData);
-    logger.info('   Token data saved to state');
+    api.logger.info('   Token data saved to state');
 
     if (normalisedParams.alias) {
       api.alias.register({
@@ -327,7 +327,7 @@ export class TokenCreateFtCommand extends BaseTransactionCommand<
         entityId: tokenId,
         createdAt: result.consensusTimestamp,
       });
-      logger.info(`   Name registered: ${normalisedParams.alias}`);
+      api.logger.info(`   Name registered: ${normalisedParams.alias}`);
     }
 
     const outputData: TokenCreateFtOutput = {

--- a/src/plugins/token/commands/create-nft-from-file/handler.ts
+++ b/src/plugins/token/commands/create-nft-from-file/handler.ts
@@ -253,7 +253,6 @@ export class TokenCreateNftFromFileCommand extends BaseTransactionCommand<
       tokenId,
       normalisedParams.associations,
       api,
-      api.logger,
       normalisedParams.keyManager,
     );
     tokenData.associations = successfulAssociations;

--- a/src/plugins/token/commands/create-nft-from-file/handler.ts
+++ b/src/plugins/token/commands/create-nft-from-file/handler.ts
@@ -41,17 +41,17 @@ export class TokenCreateNftFromFileCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TokenCreateNftFromFileNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TokenCreateNftFromFileInputSchema.parse(args.args);
     const keyManager =
       validArgs.keyManager ??
       api.config.getOption<KeyManager>(ConfigOptionKey.default_key_manager);
 
-    logger.info(`Creating NFT token from file: ${validArgs.file}`);
+    api.logger.info(`Creating NFT token from file: ${validArgs.file}`);
 
     const tokenDefinition = await readAndValidateNftTokenFile(
       validArgs.file,
-      logger,
+      api.logger,
     );
     const network = api.network.getCurrentNetwork();
     api.alias.availableOrThrow(tokenDefinition.name, network);
@@ -69,7 +69,7 @@ export class TokenCreateNftFromFileCommand extends BaseTransactionCommand<
       api.keyResolver,
       'token:admin',
     );
-    logger.info(`Resolved ${adminKeys.length} admin key(s) for signing`);
+    api.logger.info(`Resolved ${adminKeys.length} admin key(s) for signing`);
 
     const supplyKeys = await resolveOptionalKeys(
       tokenDefinition.supplyKey,
@@ -77,7 +77,7 @@ export class TokenCreateNftFromFileCommand extends BaseTransactionCommand<
       api.keyResolver,
       'token:supply',
     );
-    logger.info(`Resolved ${supplyKeys.length} supply key(s)`);
+    api.logger.info(`Resolved ${supplyKeys.length} supply key(s)`);
 
     const wipeKeys = await resolveOptionalKeys(
       tokenDefinition.wipeKey,
@@ -201,12 +201,12 @@ export class TokenCreateNftFromFileCommand extends BaseTransactionCommand<
     normalisedParams: TokenCreateNftFromFileNormalizedParams,
     buildTransactionResult: TokenCreateNftFromFileBuildTransactionResult,
   ): Promise<TokenCreateNftFromFileSignTransactionResult> {
-    const { api, logger } = args;
+    const { api } = args;
     const signingKeys = [
       ...normalisedParams.adminKeys.map((k) => k.keyRefId),
       normalisedParams.treasury.keyRefId,
     ];
-    logger.info(
+    api.logger.info(
       `🔑 Signing transaction with admin and treasury keys (${signingKeys.length} keys)`,
     );
     const transaction = await api.txSign.sign(
@@ -243,8 +243,8 @@ export class TokenCreateNftFromFileCommand extends BaseTransactionCommand<
     _signTransactionResult: TokenCreateNftFromFileSignTransactionResult,
     executeTransactionResult: TokenCreateNftFromFileExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const { api } = args;
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const result = executeTransactionResult.transactionResult;
     const tokenData = buildNftTokenDataFromFile(result, normalisedParams);
 
@@ -253,14 +253,14 @@ export class TokenCreateNftFromFileCommand extends BaseTransactionCommand<
       tokenId,
       normalisedParams.associations,
       api,
-      logger,
+      api.logger,
       normalisedParams.keyManager,
     );
     tokenData.associations = successfulAssociations;
 
     const key = composeKey(normalisedParams.network, tokenId);
     tokenState.saveToken(key, tokenData);
-    logger.info('   Token data saved to state');
+    api.logger.info('   Token data saved to state');
 
     if (normalisedParams.alias && result.tokenId) {
       api.alias.register({
@@ -270,7 +270,7 @@ export class TokenCreateNftFromFileCommand extends BaseTransactionCommand<
         entityId: tokenId,
         createdAt: result.consensusTimestamp,
       });
-      logger.info(`   Name registered: ${normalisedParams.alias}`);
+      api.logger.info(`   Name registered: ${normalisedParams.alias}`);
     }
 
     const associations: TokenCreateNftFromFileAssociationOutput[] =

--- a/src/plugins/token/commands/create-nft/handler.ts
+++ b/src/plugins/token/commands/create-nft/handler.ts
@@ -39,7 +39,7 @@ export class TokenCreateNftCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TokenCreateNftNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TokenCreateNftInputSchema.parse(args.args);
     const keyManager =
       validArgs.keyManager ??
@@ -121,20 +121,22 @@ export class TokenCreateNftCommand extends BaseTransactionCommand<
     let finalMaxSupply: bigint | undefined;
     if (validArgs.supplyType === SupplyType.FINITE) {
       finalMaxSupply = determineFiniteMaxSupply(maxSupply, 0n);
-      logger.info(`Max supply: ${finalMaxSupply}`);
+      api.logger.info(`Max supply: ${finalMaxSupply}`);
     } else if (maxSupply !== undefined) {
-      logger.warn(
+      api.logger.warn(
         'Max supply specified for INFINITE supply type - ignoring max supply parameter',
       );
     }
 
-    logger.info(`Creating NFT: ${validArgs.tokenName} (${validArgs.symbol})`);
-    logger.debug('=== NFT PARAMS DEBUG ===');
-    logger.debug(`Treasury ID: ${treasury.keyRefId}`);
-    logger.debug(`Admin Keys count: ${admin.length}`);
-    logger.debug(`Supply Keys count: ${supply.length}`);
-    logger.debug(`Use Custom Treasury: ${String(Boolean(treasury))}`);
-    logger.debug('=========================');
+    api.logger.info(
+      `Creating NFT: ${validArgs.tokenName} (${validArgs.symbol})`,
+    );
+    api.logger.debug('=== NFT PARAMS DEBUG ===');
+    api.logger.debug(`Treasury ID: ${treasury.keyRefId}`);
+    api.logger.debug(`Admin Keys count: ${admin.length}`);
+    api.logger.debug(`Supply Keys count: ${supply.length}`);
+    api.logger.debug(`Use Custom Treasury: ${String(Boolean(treasury))}`);
+    api.logger.debug('=========================');
 
     return {
       name: validArgs.tokenName,
@@ -286,8 +288,8 @@ export class TokenCreateNftCommand extends BaseTransactionCommand<
     _signTransactionResult: TokenCreateNftSignTransactionResult,
     executeTransactionResult: TokenCreateNftExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const { api } = args;
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const result = executeTransactionResult.transactionResult;
     const tokenId = result.tokenId ?? '';
 
@@ -322,7 +324,7 @@ export class TokenCreateNftCommand extends BaseTransactionCommand<
 
     const key = composeKey(normalisedParams.network, tokenId);
     tokenState.saveToken(key, tokenData);
-    logger.info('   Non-fungible token data saved to state');
+    api.logger.info('   Non-fungible token data saved to state');
 
     if (normalisedParams.alias) {
       api.alias.register({
@@ -332,7 +334,7 @@ export class TokenCreateNftCommand extends BaseTransactionCommand<
         entityId: tokenId,
         createdAt: result.consensusTimestamp,
       });
-      logger.info(`   Name registered: ${normalisedParams.alias}`);
+      api.logger.info(`   Name registered: ${normalisedParams.alias}`);
     }
 
     const outputData: TokenCreateNftOutput = {

--- a/src/plugins/token/commands/delete-allowance-nft/handler.ts
+++ b/src/plugins/token/commands/delete-allowance-nft/handler.ts
@@ -39,7 +39,7 @@ export class TokenDeleteAllowanceNftCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<DeleteAllowanceNftNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TokenDeleteAllowanceNftInputSchema.parse(args.args);
     const keyManager =
       validArgs.keyManager ??
@@ -84,8 +84,8 @@ export class TokenDeleteAllowanceNftCommand extends BaseTransactionCommand<
       spenderAccountId = resolvedSpender.accountId;
     }
 
-    logger.info(`🔑 Using owner account: ${resolvedOwner.accountId}`);
-    logger.info(
+    api.logger.info(`🔑 Using owner account: ${resolvedOwner.accountId}`);
+    api.logger.info(
       validArgs.allSerials
         ? `Revoking all-serials blanket approval of ${tokenId} for spender ${spenderAccountId}`
         : `Deleting allowance for serials [${validArgs.serials?.join(', ')}] of ${tokenId}`,
@@ -145,8 +145,8 @@ export class TokenDeleteAllowanceNftCommand extends BaseTransactionCommand<
     normalisedParams: DeleteAllowanceNftNormalizedParams,
     buildTransactionResult: DeleteAllowanceNftBuildTransactionResult,
   ): Promise<DeleteAllowanceNftSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using key ${normalisedParams.signerKeyRefId} for signing transaction`,
     );
     const signedTransaction = await api.txSign.sign(

--- a/src/plugins/token/commands/delete/handler.ts
+++ b/src/plugins/token/commands/delete/handler.ts
@@ -47,7 +47,7 @@ export class TokenDeleteCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     validArgs: TokenDeleteInput,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
     if (validArgs.adminKey.length > 0) {
       throw new ValidationError(
@@ -56,7 +56,7 @@ export class TokenDeleteCommand extends BaseTransactionCommand<
     }
 
     const network = api.network.getCurrentNetwork();
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
 
     const resolvedToken = resolveTokenParameter(validArgs.token, api, network);
     if (!resolvedToken) {
@@ -104,7 +104,7 @@ export class TokenDeleteCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TokenDeleteNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = TokenDeleteInputSchema.parse(args.args);
 
@@ -124,7 +124,7 @@ export class TokenDeleteCommand extends BaseTransactionCommand<
 
     const tokenInfo = await api.mirror.getTokenInfo(tokenId);
 
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const stateKey = composeKey(network, tokenId);
     const tokenInState = tokenState.getToken(stateKey);
 
@@ -154,8 +154,8 @@ export class TokenDeleteCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: TokenDeleteNormalizedParams,
   ): Promise<TokenDeleteBuildTransactionResult> {
-    const { logger } = args;
-    logger.debug('Building token delete transaction');
+    const { api } = args;
+    api.logger.debug('Building token delete transaction');
     const transaction = args.api.token.createDeleteTransaction({
       tokenId: normalisedParams.tokenId,
     });
@@ -167,8 +167,8 @@ export class TokenDeleteCommand extends BaseTransactionCommand<
     normalisedParams: TokenDeleteNormalizedParams,
     buildTransactionResult: TokenDeleteBuildTransactionResult,
   ): Promise<TokenDeleteSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using ${normalisedParams.keyRefIds.length} key(s) for signing transaction`,
     );
     const signedTransaction = await api.txSign.sign(
@@ -206,10 +206,10 @@ export class TokenDeleteCommand extends BaseTransactionCommand<
     _signTransactionResult: TokenDeleteSignTransactionResult,
     executeTransactionResult: TokenDeleteExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
     const { network, tokenId, tokenName } = normalisedParams;
 
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const key = composeKey(network, tokenId);
     const tokenInState = tokenState.getToken(key);
 

--- a/src/plugins/token/commands/dissociate/handler.ts
+++ b/src/plugins/token/commands/dissociate/handler.ts
@@ -33,7 +33,7 @@ export class TokenDissociateCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<DissociateNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TokenDissociateInputSchema.parse(args.args);
     const keyManager =
       validArgs.keyManager ??
@@ -55,9 +55,9 @@ export class TokenDissociateCommand extends BaseTransactionCommand<
       ['token:dissociate'],
     );
 
-    logger.info(`🔑 Using account: ${account.accountId}`);
-    logger.info('🔑 Will sign with account key');
-    logger.info(
+    api.logger.info(`🔑 Using account: ${account.accountId}`);
+    api.logger.info('🔑 Will sign with account key');
+    api.logger.info(
       `Dissociating token ${tokenId} from account ${account.accountId}`,
     );
 
@@ -101,8 +101,8 @@ export class TokenDissociateCommand extends BaseTransactionCommand<
     normalisedParams: DissociateNormalizedParams,
     buildTransactionResult: DissociateBuildTransactionResult,
   ): Promise<DissociateSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using key ${normalisedParams.account.keyRefId} for signing transaction`,
     );
     const signedTransaction = await api.txSign.sign(
@@ -144,14 +144,14 @@ export class TokenDissociateCommand extends BaseTransactionCommand<
     _signTransactionResult: DissociateSignTransactionResult,
     executeTransactionResult: DissociateExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const { api } = args;
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     removeAssociationFromState(
       tokenState,
       normalisedParams.tokenId,
       normalisedParams.account.accountId,
       normalisedParams.network,
-      logger,
+      api.logger,
     );
 
     const outputData: TokenDissociateOutput = {

--- a/src/plugins/token/commands/freeze/handler.ts
+++ b/src/plugins/token/commands/freeze/handler.ts
@@ -35,7 +35,7 @@ export class TokenFreezeCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<FreezeNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = TokenFreezeInputSchema.parse(args.args);
 
@@ -61,7 +61,7 @@ export class TokenFreezeCommand extends BaseTransactionCommand<
       network,
     });
 
-    logger.info(
+    api.logger.info(
       `Freezing account ${accountId} for token ${tokenId} on ${network}`,
     );
 
@@ -88,8 +88,8 @@ export class TokenFreezeCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: FreezeNormalizedParams,
   ): Promise<FreezeBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building token freeze transaction');
+    const { api } = args;
+    api.logger.debug('Building token freeze transaction');
     const transaction = api.token.createFreezeTransaction({
       tokenId: normalisedParams.tokenId,
       accountId: normalisedParams.accountId,
@@ -102,8 +102,8 @@ export class TokenFreezeCommand extends BaseTransactionCommand<
     normalisedParams: FreezeNormalizedParams,
     buildTransactionResult: FreezeBuildTransactionResult,
   ): Promise<FreezeSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using ${normalisedParams.keyRefIds.length} key(s) for signing transaction`,
     );
     const signedTransaction = await api.txSign.sign(

--- a/src/plugins/token/commands/grant-kyc/handler.ts
+++ b/src/plugins/token/commands/grant-kyc/handler.ts
@@ -35,7 +35,7 @@ export class TokenGrantKycCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<GrantKycNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = TokenGrantKycInputSchema.parse(args.args);
 
@@ -61,7 +61,7 @@ export class TokenGrantKycCommand extends BaseTransactionCommand<
       network,
     });
 
-    logger.info(
+    api.logger.info(
       `Granting KYC for account ${accountId} on token ${tokenId} on ${network}`,
     );
 
@@ -88,8 +88,8 @@ export class TokenGrantKycCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: GrantKycNormalizedParams,
   ): Promise<GrantKycBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building token grant KYC transaction');
+    const { api } = args;
+    api.logger.debug('Building token grant KYC transaction');
     const transaction = api.token.createGrantKycTransaction({
       tokenId: normalisedParams.tokenId,
       accountId: normalisedParams.accountId,
@@ -102,8 +102,8 @@ export class TokenGrantKycCommand extends BaseTransactionCommand<
     normalisedParams: GrantKycNormalizedParams,
     buildTransactionResult: GrantKycBuildTransactionResult,
   ): Promise<GrantKycSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using ${normalisedParams.keyRefIds.length} key(s) for signing transaction`,
     );
     const signedTransaction = await api.txSign.sign(

--- a/src/plugins/token/commands/import/handler.ts
+++ b/src/plugins/token/commands/import/handler.ts
@@ -36,8 +36,8 @@ export class TokenImportCommand implements Command {
   }
 
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const { api } = args;
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const parsedArgs = TokenImportInputSchema.parse(args.args);
     const validArgs: ImportTokenNormalizedParams = {
       tokenId: parsedArgs.token,

--- a/src/plugins/token/commands/list/handler.ts
+++ b/src/plugins/token/commands/list/handler.ts
@@ -10,18 +10,20 @@ import { TokenListInputSchema } from './input';
 
 export class TokenListCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const { api } = args;
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const validArgs: ListTokensNormalizedParams = TokenListInputSchema.parse(
       args.args,
     );
 
-    logger.info('Listing tokens...');
+    api.logger.info('Listing tokens...');
 
     const tokens = tokenState.listTokens();
-    logger.debug(`[TOKEN LIST] Retrieved ${tokens.length} tokens from state`);
+    api.logger.debug(
+      `[TOKEN LIST] Retrieved ${tokens.length} tokens from state`,
+    );
     tokens.forEach((token, index) => {
-      logger.debug(
+      api.logger.debug(
         `[TOKEN LIST]   ${index + 1}. ${token.name} (${token.symbol}) - ${token.tokenId} on ${token.network}`,
       );
     });

--- a/src/plugins/token/commands/mint-ft/handler.ts
+++ b/src/plugins/token/commands/mint-ft/handler.ts
@@ -38,9 +38,9 @@ export class TokenMintFtCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<MintFtNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
 
     const validArgs = TokenMintFtInputSchema.parse(args.args);
 
@@ -64,7 +64,7 @@ export class TokenMintFtCommand extends BaseTransactionCommand<
 
     const tokenId = resolvedToken.tokenId;
 
-    logger.info(`Minting tokens for token: ${tokenId}`);
+    api.logger.info(`Minting tokens for token: ${tokenId}`);
 
     const tokenInfo = await api.mirror.getTokenInfo(tokenId);
 
@@ -105,7 +105,7 @@ export class TokenMintFtCommand extends BaseTransactionCommand<
           context: { tokenId, rawAmount, totalSupply, maxSupply },
         });
       }
-      logger.info(
+      api.logger.info(
         `Token has finite supply. Current: ${totalSupply.toString()}, Max: ${maxSupply.toString()}, After mint: ${newTotalSupply.toString()}`,
       );
     }
@@ -121,8 +121,8 @@ export class TokenMintFtCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: MintFtNormalizedParams,
   ): Promise<MintFtBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building mint transaction body');
+    const { api } = args;
+    api.logger.debug('Building mint transaction body');
     const transaction = api.token.createMintTransaction({
       tokenId: normalisedParams.tokenId,
       amount: normalisedParams.rawAmount,
@@ -137,8 +137,8 @@ export class TokenMintFtCommand extends BaseTransactionCommand<
     normalisedParams: MintFtNormalizedParams,
     buildTransactionResult: MintFtBuildTransactionResult,
   ): Promise<MintFtSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using ${normalisedParams.keyRefIds.length} key(s) for signing transaction`,
     );
     const transaction = await api.txSign.sign(

--- a/src/plugins/token/commands/mint-nft/handler.ts
+++ b/src/plugins/token/commands/mint-nft/handler.ts
@@ -37,8 +37,8 @@ export class TokenMintNftCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TokenMintNftNormalizedParams> {
-    const { api, logger } = args;
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const { api } = args;
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const validArgs = TokenMintNftInputSchema.parse(args.args);
     const keyManager =
       validArgs.keyManager ||
@@ -53,7 +53,7 @@ export class TokenMintNftCommand extends BaseTransactionCommand<
     }
 
     const tokenId = resolvedToken.tokenId;
-    logger.info(`Minting NFT for token: ${tokenId}`);
+    api.logger.info(`Minting NFT for token: ${tokenId}`);
 
     const metadataBytes = new TextEncoder().encode(validArgs.metadata);
     if (metadataBytes.length > MAX_NFT_METADATA_BYTES) {
@@ -93,7 +93,7 @@ export class TokenMintNftCommand extends BaseTransactionCommand<
           context: { tokenId, totalSupply, maxSupply },
         });
       }
-      logger.info(
+      api.logger.info(
         `Token has finite supply. Current: ${totalSupply.toString()}, Max: ${maxSupply.toString()}, After mint: ${newTotalSupply.toString()}`,
       );
     }
@@ -123,8 +123,8 @@ export class TokenMintNftCommand extends BaseTransactionCommand<
     normalisedParams: TokenMintNftNormalizedParams,
     buildTransactionResult: TokenMintNftBuildTransactionResult,
   ): Promise<TokenMintNftSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using ${normalisedParams.keyRefIds.length} key(s) for signing transaction`,
     );
     const transaction = await api.txSign.sign(

--- a/src/plugins/token/commands/pause/handler.ts
+++ b/src/plugins/token/commands/pause/handler.ts
@@ -35,7 +35,7 @@ export class TokenPauseCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<PauseNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = TokenPauseInputSchema.parse(args.args);
 
@@ -55,7 +55,7 @@ export class TokenPauseCommand extends BaseTransactionCommand<
 
     const tokenInfo = await api.mirror.getTokenInfo(tokenId);
 
-    logger.info(`Pausing token ${tokenId} on ${network}`);
+    api.logger.info(`Pausing token ${tokenId} on ${network}`);
 
     const { keyRefIds } = await api.keyResolver.resolveSigningKeys({
       mirrorRoleKey: tokenInfo.pause_key,
@@ -79,8 +79,8 @@ export class TokenPauseCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: PauseNormalizedParams,
   ): Promise<PauseBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building token pause transaction');
+    const { api } = args;
+    api.logger.debug('Building token pause transaction');
     const transaction = api.token.createPauseTransaction({
       tokenId: normalisedParams.tokenId,
     });
@@ -92,8 +92,8 @@ export class TokenPauseCommand extends BaseTransactionCommand<
     normalisedParams: PauseNormalizedParams,
     buildTransactionResult: PauseBuildTransactionResult,
   ): Promise<PauseSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using ${normalisedParams.keyRefIds.length} key(s) for signing transaction`,
     );
     const signedTransaction = await api.txSign.sign(

--- a/src/plugins/token/commands/pending-airdrops/handler.ts
+++ b/src/plugins/token/commands/pending-airdrops/handler.ts
@@ -20,14 +20,14 @@ const PAGE_LIMIT = 100;
 
 export class TokenPendingAirdropsCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs: PendingAirdropsNormalizedParams =
       TokenPendingAirdropsInputSchema.parse(args.args);
     const network = api.network.getCurrentNetwork();
 
     const accountId = this.resolveAccountId(validArgs.account, api, network);
 
-    logger.info(`Fetching pending airdrops for ${accountId}...`);
+    api.logger.info(`Fetching pending airdrops for ${accountId}...`);
     const allAirdrops = await this.fetchAirdrops(
       api,
       accountId,
@@ -37,7 +37,7 @@ export class TokenPendingAirdropsCommand implements Command {
     const uniqueTokenIds = [...new Set(allAirdrops.map((a) => a.token_id))];
     const tokenInfoMap = await this.fetchTokenInfoMap(
       api,
-      logger,
+      api.logger,
       uniqueTokenIds,
     );
 
@@ -120,7 +120,7 @@ export class TokenPendingAirdropsCommand implements Command {
   ): Promise<Map<string, { name: string; symbol: string }>> {
     const entries = await Promise.all(
       tokenIds.map(async (tokenId) => {
-        logger.info(`Fetching token info for ${tokenId}...`);
+        api.logger.info(`Fetching token info for ${tokenId}...`);
         const info = await api.mirror.getTokenInfo(tokenId);
         return [tokenId, { name: info.name, symbol: info.symbol }] as const;
       }),

--- a/src/plugins/token/commands/pending-airdrops/handler.ts
+++ b/src/plugins/token/commands/pending-airdrops/handler.ts
@@ -1,7 +1,6 @@
 import type { CommandHandlerArgs, CommandResult } from '@/core';
 import type { Command } from '@/core/commands/command.interface';
 import type { CoreApi } from '@/core/core-api/core-api.interface';
-import type { Logger } from '@/core/services/logger/logger-service.interface';
 import type { TokenAirdropItem } from '@/core/services/mirrornode/types';
 import type { SupportedNetwork } from '@/core/types/shared.types';
 import type { TokenPendingAirdropsOutput } from './output';
@@ -35,11 +34,7 @@ export class TokenPendingAirdropsCommand implements Command {
     );
 
     const uniqueTokenIds = [...new Set(allAirdrops.map((a) => a.token_id))];
-    const tokenInfoMap = await this.fetchTokenInfoMap(
-      api,
-      api.logger,
-      uniqueTokenIds,
-    );
+    const tokenInfoMap = await this.fetchTokenInfoMap(api, uniqueTokenIds);
 
     const hasMore = !validArgs.showAll && allAirdrops.length >= PAGE_LIMIT;
 
@@ -115,7 +110,6 @@ export class TokenPendingAirdropsCommand implements Command {
 
   private async fetchTokenInfoMap(
     api: CoreApi,
-    logger: Logger,
     tokenIds: string[],
   ): Promise<Map<string, { name: string; symbol: string }>> {
     const entries = await Promise.all(

--- a/src/plugins/token/commands/reject-airdrop/handler.ts
+++ b/src/plugins/token/commands/reject-airdrop/handler.ts
@@ -33,7 +33,7 @@ export class TokenRejectAirdropCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TokenRejectAirdropNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const {
       owner,
       token: tokenId,
@@ -54,7 +54,7 @@ export class TokenRejectAirdropCommand extends BaseTransactionCommand<
         network,
       });
 
-    logger.info(`Fetching token info for ${tokenId}...`);
+    api.logger.info(`Fetching token info for ${tokenId}...`);
     const tokenInfo = await api.mirror.getTokenInfo(tokenId);
     const isNft = tokenInfo.type === MirrorNodeTokenType.NON_FUNGIBLE_UNIQUE;
 
@@ -98,7 +98,7 @@ export class TokenRejectAirdropCommand extends BaseTransactionCommand<
 
     const { keyRefId: signerKeyRefId } = resolvedAccount;
 
-    logger.info(`Rejecting token ${tokenId} for ${ownerAccountId}`);
+    api.logger.info(`Rejecting token ${tokenId} for ${ownerAccountId}`);
 
     return {
       network,
@@ -114,8 +114,8 @@ export class TokenRejectAirdropCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: TokenRejectAirdropNormalizedParams,
   ): Promise<TokenRejectAirdropBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building reject transaction body');
+    const { api } = args;
+    api.logger.debug('Building reject transaction body');
 
     const transaction = api.token.createRejectAirdropTransaction({
       ownerAccountId: normalisedParams.ownerAccountId,
@@ -130,8 +130,10 @@ export class TokenRejectAirdropCommand extends BaseTransactionCommand<
     normalisedParams: TokenRejectAirdropNormalizedParams,
     buildTransactionResult: TokenRejectAirdropBuildTransactionResult,
   ): Promise<TokenRejectAirdropSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(`Using key ${normalisedParams.signerKeyRefId} for signing`);
+    const { api } = args;
+    api.logger.debug(
+      `Using key ${normalisedParams.signerKeyRefId} for signing`,
+    );
 
     const signedTransaction = await api.txSign.sign(
       buildTransactionResult.transaction,

--- a/src/plugins/token/commands/revoke-kyc/handler.ts
+++ b/src/plugins/token/commands/revoke-kyc/handler.ts
@@ -35,7 +35,7 @@ export class TokenRevokeKycCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<RevokeKycNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = TokenRevokeKycInputSchema.parse(args.args);
 
@@ -61,7 +61,7 @@ export class TokenRevokeKycCommand extends BaseTransactionCommand<
       network,
     });
 
-    logger.info(
+    api.logger.info(
       `Revoking KYC for account ${accountId} on token ${tokenId} on ${network}`,
     );
 
@@ -88,8 +88,8 @@ export class TokenRevokeKycCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: RevokeKycNormalizedParams,
   ): Promise<RevokeKycBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building token revoke KYC transaction');
+    const { api } = args;
+    api.logger.debug('Building token revoke KYC transaction');
     const transaction = api.token.createRevokeKycTransaction({
       tokenId: normalisedParams.tokenId,
       accountId: normalisedParams.accountId,
@@ -102,8 +102,8 @@ export class TokenRevokeKycCommand extends BaseTransactionCommand<
     normalisedParams: RevokeKycNormalizedParams,
     buildTransactionResult: RevokeKycBuildTransactionResult,
   ): Promise<RevokeKycSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using ${normalisedParams.keyRefIds.length} key(s) for signing transaction`,
     );
     const signedTransaction = await api.txSign.sign(

--- a/src/plugins/token/commands/transfer-ft/handler.ts
+++ b/src/plugins/token/commands/transfer-ft/handler.ts
@@ -37,9 +37,9 @@ export class TokenTransferFtCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TokenTransferFtNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
 
     const validArgs = TokenTransferFtInputSchema.parse(args.args);
 
@@ -90,8 +90,8 @@ export class TokenTransferFtCommand extends BaseTransactionCommand<
     const { accountId: fromAccountId, keyRefId: signerKeyRefId } =
       resolvedFromAccount;
 
-    logger.info(`🔑 Using from account: ${fromAccountId}`);
-    logger.info(`🔑 Will sign with from account key`);
+    api.logger.info(`🔑 Using from account: ${fromAccountId}`);
+    api.logger.info(`🔑 Will sign with from account key`);
 
     const resolvedToAccount = resolveDestinationAccountParameter(
       to,
@@ -107,7 +107,7 @@ export class TokenTransferFtCommand extends BaseTransactionCommand<
 
     const toAccountId = resolvedToAccount.accountId;
 
-    logger.info(
+    api.logger.info(
       `Transferring ${rawAmount.toString()} tokens of ${tokenId} from ${fromAccountId} to ${toAccountId}`,
     );
 
@@ -126,8 +126,8 @@ export class TokenTransferFtCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: TokenTransferFtNormalizedParams,
   ): Promise<TokenTransferFtBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building transfer transaction body');
+    const { api } = args;
+    api.logger.debug('Building transfer transaction body');
     const transaction = api.transfer.buildTransferTransaction([
       new FtTransferEntry(
         normalisedParams.fromAccountId,
@@ -146,9 +146,9 @@ export class TokenTransferFtCommand extends BaseTransactionCommand<
     normalisedParams: TokenTransferFtNormalizedParams,
     buildTransactionResult: TokenTransferFtBuildTransactionResult,
   ): Promise<TokenTransferFtSignTransactionResult> {
-    const { api, logger } = args;
+    const { api } = args;
     const signerKeyRefId = normalisedParams.signerKeyRefId;
-    logger.debug(`Using key ${signerKeyRefId} for signing transaction`);
+    api.logger.debug(`Using key ${signerKeyRefId} for signing transaction`);
     const transaction = await api.txSign.sign(
       buildTransactionResult.transaction,
       [signerKeyRefId],

--- a/src/plugins/token/commands/transfer-nft/handler.ts
+++ b/src/plugins/token/commands/transfer-nft/handler.ts
@@ -39,7 +39,7 @@ export class TokenTransferNftCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TransferNftNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TokenTransferNftInputSchema.parse(args.args);
     const keyManager =
       validArgs.keyManager ||
@@ -70,8 +70,8 @@ export class TokenTransferNftCommand extends BaseTransactionCommand<
     const fromAccountId = resolvedFromAccount.accountId;
     const signerKeyRefId = resolvedFromAccount.keyRefId;
 
-    logger.info(`🔑 Using from account: ${fromAccountId}`);
-    logger.info('🔑 Will sign with from account key');
+    api.logger.info(`🔑 Using from account: ${fromAccountId}`);
+    api.logger.info('🔑 Will sign with from account key');
 
     for (const serial of validArgs.serials) {
       const nftInfo = await api.mirror.getNftInfo(tokenId, serial);
@@ -101,7 +101,7 @@ export class TokenTransferNftCommand extends BaseTransactionCommand<
       );
     }
 
-    logger.info(
+    api.logger.info(
       `Transferring ${validArgs.serials.length} NFT(s) of ${tokenId} from ${fromAccountId} to ${resolvedToAccount.accountId}`,
     );
 
@@ -140,8 +140,8 @@ export class TokenTransferNftCommand extends BaseTransactionCommand<
     normalisedParams: TransferNftNormalizedParams,
     buildTransactionResult: TransferNftBuildTransactionResult,
   ): Promise<TransferNftSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using key ${normalisedParams.signerKeyRefId} for signing transaction`,
     );
     const transaction = await api.txSign.sign(

--- a/src/plugins/token/commands/unfreeze/handler.ts
+++ b/src/plugins/token/commands/unfreeze/handler.ts
@@ -35,7 +35,7 @@ export class TokenUnfreezeCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<UnfreezeNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = TokenUnfreezeInputSchema.parse(args.args);
 
@@ -61,7 +61,7 @@ export class TokenUnfreezeCommand extends BaseTransactionCommand<
       network,
     });
 
-    logger.info(
+    api.logger.info(
       `Unfreezing account ${accountId} for token ${tokenId} on ${network}`,
     );
 
@@ -88,8 +88,8 @@ export class TokenUnfreezeCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: UnfreezeNormalizedParams,
   ): Promise<UnfreezeBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building token unfreeze transaction');
+    const { api } = args;
+    api.logger.debug('Building token unfreeze transaction');
     const transaction = api.token.createUnfreezeTransaction({
       tokenId: normalisedParams.tokenId,
       accountId: normalisedParams.accountId,
@@ -102,8 +102,8 @@ export class TokenUnfreezeCommand extends BaseTransactionCommand<
     normalisedParams: UnfreezeNormalizedParams,
     buildTransactionResult: UnfreezeBuildTransactionResult,
   ): Promise<UnfreezeSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using ${normalisedParams.keyRefIds.length} key(s) for signing transaction`,
     );
     const signedTransaction = await api.txSign.sign(

--- a/src/plugins/token/commands/unpause/handler.ts
+++ b/src/plugins/token/commands/unpause/handler.ts
@@ -35,7 +35,7 @@ export class TokenUnpauseCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<UnpauseNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validArgs = TokenUnpauseInputSchema.parse(args.args);
 
@@ -55,7 +55,7 @@ export class TokenUnpauseCommand extends BaseTransactionCommand<
 
     const tokenInfo = await api.mirror.getTokenInfo(tokenId);
 
-    logger.info(`Unpausing token ${tokenId} on ${network}`);
+    api.logger.info(`Unpausing token ${tokenId} on ${network}`);
 
     const { keyRefIds } = await api.keyResolver.resolveSigningKeys({
       mirrorRoleKey: tokenInfo.pause_key,
@@ -79,8 +79,8 @@ export class TokenUnpauseCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: UnpauseNormalizedParams,
   ): Promise<UnpauseBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building token unpause transaction');
+    const { api } = args;
+    api.logger.debug('Building token unpause transaction');
     const transaction = api.token.createUnpauseTransaction({
       tokenId: normalisedParams.tokenId,
     });
@@ -92,8 +92,8 @@ export class TokenUnpauseCommand extends BaseTransactionCommand<
     normalisedParams: UnpauseNormalizedParams,
     buildTransactionResult: UnpauseBuildTransactionResult,
   ): Promise<UnpauseSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using ${normalisedParams.keyRefIds.length} key(s) for signing transaction`,
     );
     const signedTransaction = await api.txSign.sign(

--- a/src/plugins/token/commands/update-metadata-nft/handler.ts
+++ b/src/plugins/token/commands/update-metadata-nft/handler.ts
@@ -39,8 +39,8 @@ export class TokenUpdateNftMetadataCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<UpdateNftMetadataNormalizedParams> {
-    const { api, logger } = args;
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const { api } = args;
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const validArgs = TokenUpdateNftMetadataInputSchema.parse(args.args);
     const keyManager =
       validArgs.keyManager ||
@@ -55,7 +55,7 @@ export class TokenUpdateNftMetadataCommand extends BaseTransactionCommand<
     }
 
     const tokenId = resolvedToken.tokenId;
-    logger.info(`Updating NFT metadata for token: ${tokenId}`);
+    api.logger.info(`Updating NFT metadata for token: ${tokenId}`);
 
     const metadataBytes = new TextEncoder().encode(validArgs.metadata);
     if (metadataBytes.length > MAX_NFT_METADATA_BYTES) {
@@ -117,8 +117,8 @@ export class TokenUpdateNftMetadataCommand extends BaseTransactionCommand<
     normalisedParams: UpdateNftMetadataNormalizedParams,
     buildTransactionResult: UpdateNftMetadataBuildTransactionResult,
   ): Promise<UpdateNftMetadataSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using ${normalisedParams.keyRefIds.length} key(s) for signing transaction`,
     );
     const transaction = await api.txSign.sign(

--- a/src/plugins/token/commands/update/handler.ts
+++ b/src/plugins/token/commands/update/handler.ts
@@ -48,7 +48,7 @@ export class TokenUpdateCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<TokenUpdateNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TokenUpdateInputSchema.parse(args.args);
 
     const network = api.network.getCurrentNetwork();
@@ -152,7 +152,7 @@ export class TokenUpdateCommand extends BaseTransactionCommand<
       ? new TextEncoder().encode(validArgs.metadata)
       : undefined;
 
-    logger.info(`Updating token ${tokenId} on ${network}`);
+    api.logger.info(`Updating token ${tokenId} on ${network}`);
 
     return {
       tokenId,
@@ -297,8 +297,8 @@ export class TokenUpdateCommand extends BaseTransactionCommand<
     _signTransactionResult: TokenUpdateSignTransactionResult,
     executeTransactionResult: TokenUpdateExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const { api } = args;
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const tokenInfo = normalisedParams.tokenInfo;
 
     const updatedFields = this.buildUpdatedFields(normalisedParams);
@@ -312,7 +312,7 @@ export class TokenUpdateCommand extends BaseTransactionCommand<
     );
 
     tokenState.saveToken(normalisedParams.stateKey, tokenData);
-    logger.info('Token data saved to state');
+    api.logger.info('Token data saved to state');
 
     const outputData: TokenUpdateOutput = {
       tokenId: normalisedParams.tokenId,

--- a/src/plugins/token/commands/view/handler.ts
+++ b/src/plugins/token/commands/view/handler.ts
@@ -13,7 +13,7 @@ import { TokenViewInputSchema } from './input';
 
 export class TokenViewCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs: ViewTokenNormalizedParams = TokenViewInputSchema.parse(
       args.args,
     );
@@ -27,7 +27,7 @@ export class TokenViewCommand implements Command {
     }
 
     const tokenId = resolvedToken.tokenId;
-    logger.info(`Fetching token info for ${tokenId}...`);
+    api.logger.info(`Fetching token info for ${tokenId}...`);
     const tokenInfo = await api.mirror.getTokenInfo(tokenId);
 
     let nftInfo: NftInfo | null = null;
@@ -45,7 +45,7 @@ export class TokenViewCommand implements Command {
         });
       }
 
-      logger.info(`Fetching NFT serial #${serialNum}...`);
+      api.logger.info(`Fetching NFT serial #${serialNum}...`);
       nftInfo = await api.mirror.getNftInfo(tokenId, serialNum);
     }
     const output: TokenViewOutput = tokenBuildOutput(

--- a/src/plugins/token/commands/wipe-ft/handler.ts
+++ b/src/plugins/token/commands/wipe-ft/handler.ts
@@ -43,9 +43,9 @@ export class TokenWipeFtCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<WipeFtNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const validArgs = TokenWipeFtInputSchema.parse(args.args);
 
     const keyManager =
@@ -104,7 +104,7 @@ export class TokenWipeFtCommand extends BaseTransactionCommand<
 
     const currentTotalSupply = BigInt(tokenInfo.total_supply || '0');
 
-    logger.info(
+    api.logger.info(
       `Wiping ${rawAmount.toString()} tokens from account ${accountId}. Current supply: ${currentTotalSupply.toString()}`,
     );
 
@@ -122,8 +122,8 @@ export class TokenWipeFtCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: WipeFtNormalizedParams,
   ): Promise<WipeFtBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building FT wipe transaction body');
+    const { api } = args;
+    api.logger.debug('Building FT wipe transaction body');
     const transaction = api.token.createWipeFtTransaction({
       tokenId: normalisedParams.tokenId,
       accountId: normalisedParams.accountId,
@@ -137,8 +137,8 @@ export class TokenWipeFtCommand extends BaseTransactionCommand<
     normalisedParams: WipeFtNormalizedParams,
     buildTransactionResult: WipeFtBuildTransactionResult,
   ): Promise<WipeFtSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using ${normalisedParams.keyRefIds.length} key(s) for signing transaction`,
     );
     const signedTransaction = await api.txSign.sign(

--- a/src/plugins/token/commands/wipe-nft/handler.ts
+++ b/src/plugins/token/commands/wipe-nft/handler.ts
@@ -42,9 +42,9 @@ export class TokenWipeNftCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<WipeNftNormalizedParams> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const validArgs = TokenWipeNftInputSchema.parse(args.args);
 
     const keyManager =
@@ -96,7 +96,7 @@ export class TokenWipeNftCommand extends BaseTransactionCommand<
     const serialNumbers = validArgs.serials;
     const currentTotalSupply = BigInt(tokenInfo.total_supply || '0');
 
-    logger.info(
+    api.logger.info(
       `Wiping ${serialNumbers.length} NFT serial(s) from account ${accountId}. Current supply: ${currentTotalSupply.toString()}`,
     );
 
@@ -114,8 +114,8 @@ export class TokenWipeNftCommand extends BaseTransactionCommand<
     args: CommandHandlerArgs,
     normalisedParams: WipeNftNormalizedParams,
   ): Promise<WipeNftBuildTransactionResult> {
-    const { api, logger } = args;
-    logger.debug('Building NFT wipe transaction body');
+    const { api } = args;
+    api.logger.debug('Building NFT wipe transaction body');
     const transaction = api.token.createWipeNftTransaction({
       tokenId: normalisedParams.tokenId,
       accountId: normalisedParams.accountId,
@@ -129,8 +129,8 @@ export class TokenWipeNftCommand extends BaseTransactionCommand<
     normalisedParams: WipeNftNormalizedParams,
     buildTransactionResult: WipeNftBuildTransactionResult,
   ): Promise<WipeNftSignTransactionResult> {
-    const { api, logger } = args;
-    logger.debug(
+    const { api } = args;
+    api.logger.debug(
       `Using ${normalisedParams.keyRefIds.length} key(s) for signing transaction`,
     );
     const signedTransaction = await api.txSign.sign(

--- a/src/plugins/token/hooks/token-associate-state/handler.ts
+++ b/src/plugins/token/hooks/token-associate-state/handler.ts
@@ -1,4 +1,4 @@
-import type { CoreApi, Logger } from '@/core';
+import type { CoreApi } from '@/core';
 import type { Hook, HookResult } from '@/core/hooks/hook.interface';
 import type { PostOutputPreparationHookParams } from '@/core/hooks/types';
 import type { BatchDataItem } from '@/core/types/shared.types';
@@ -27,16 +27,12 @@ export class TokenAssociateStateHook implements Hook<PostOutputPreparationHookPa
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOKEN_ASSOCIATE_COMMAND_NAME,
     )) {
-      this.saveAssociations(api, api.logger, batchDataItem);
+      this.saveAssociations(api, batchDataItem);
     }
     return Promise.resolve({ breakFlow: false });
   }
 
-  private saveAssociations(
-    api: CoreApi,
-    logger: Logger,
-    batchDataItem: BatchDataItem,
-  ): void {
+  private saveAssociations(api: CoreApi, batchDataItem: BatchDataItem): void {
     const parseResult = AssociateNormalizedParamsSchema.safeParse(
       batchDataItem.normalizedParams,
     );

--- a/src/plugins/token/hooks/token-associate-state/handler.ts
+++ b/src/plugins/token/hooks/token-associate-state/handler.ts
@@ -20,14 +20,14 @@ export class TokenAssociateStateHook implements Hook<PostOutputPreparationHookPa
       return Promise.resolve({ breakFlow: false });
     }
     const batchData = parsed.data.batchData;
-    const { api, logger } = params.args;
+    const { api } = params.args;
     if (!batchData.success) {
       return Promise.resolve({ breakFlow: false });
     }
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOKEN_ASSOCIATE_COMMAND_NAME,
     )) {
-      this.saveAssociations(api, logger, batchDataItem);
+      this.saveAssociations(api, api.logger, batchDataItem);
     }
     return Promise.resolve({ breakFlow: false });
   }
@@ -41,7 +41,7 @@ export class TokenAssociateStateHook implements Hook<PostOutputPreparationHookPa
       batchDataItem.normalizedParams,
     );
     if (!parseResult.success) {
-      logger.warn(
+      api.logger.warn(
         `There was a problem with parsing data schema. The saving will not be done`,
       );
       return;
@@ -49,19 +49,19 @@ export class TokenAssociateStateHook implements Hook<PostOutputPreparationHookPa
     const normalisedParams = parseResult.data;
 
     if (normalisedParams.alreadyAssociated) {
-      logger.debug(
+      api.logger.debug(
         `Skipping already associated token ${normalisedParams.tokenId} for account ${normalisedParams.account.accountId}`,
       );
       return;
     }
 
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     saveAssociationToState(
       tokenState,
       normalisedParams.tokenId,
       normalisedParams.account.accountId,
       normalisedParams.network,
-      logger,
+      api.logger,
     );
   }
 }

--- a/src/plugins/token/hooks/token-create-ft-from-file-state/handler.ts
+++ b/src/plugins/token/hooks/token-create-ft-from-file-state/handler.ts
@@ -1,4 +1,4 @@
-import type { CoreApi, Logger } from '@/core';
+import type { CoreApi } from '@/core';
 import type { Hook, HookResult } from '@/core/hooks/hook.interface';
 import type { PostOutputPreparationHookParams } from '@/core/hooks/types';
 
@@ -33,14 +33,13 @@ export class TokenCreateFtFromFileStateHook implements Hook<PostOutputPreparatio
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOKEN_CREATE_FT_FROM_FILE_COMMAND_NAME,
     )) {
-      await this.saveToken(api, api.logger, batchDataItem);
+      await this.saveToken(api, batchDataItem);
     }
     return { breakFlow: false };
   }
 
   private async saveToken(
     api: CoreApi,
-    logger: Logger,
     batchDataItem: BatchDataItem,
   ): Promise<void> {
     const parseResult = CreateFtFromFileNormalizedParamsSchema.safeParse(
@@ -82,7 +81,6 @@ export class TokenCreateFtFromFileStateHook implements Hook<PostOutputPreparatio
       innerTransactionResult.tokenId,
       normalisedParams.associations,
       api,
-      api.logger,
       normalisedParams.keyManager,
     );
 

--- a/src/plugins/token/hooks/token-create-ft-from-file-state/handler.ts
+++ b/src/plugins/token/hooks/token-create-ft-from-file-state/handler.ts
@@ -26,14 +26,14 @@ export class TokenCreateFtFromFileStateHook implements Hook<PostOutputPreparatio
       return { breakFlow: false };
     }
     const batchData = parsed.data.batchData;
-    const { api, logger } = params.args;
+    const { api } = params.args;
     if (!batchData.success) {
       return { breakFlow: false };
     }
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOKEN_CREATE_FT_FROM_FILE_COMMAND_NAME,
     )) {
-      await this.saveToken(api, logger, batchDataItem);
+      await this.saveToken(api, api.logger, batchDataItem);
     }
     return { breakFlow: false };
   }
@@ -47,7 +47,7 @@ export class TokenCreateFtFromFileStateHook implements Hook<PostOutputPreparatio
       batchDataItem.normalizedParams,
     );
     if (!parseResult.success) {
-      logger.warn(
+      api.logger.warn(
         `There was a problem with parsing data schema. The saving will not be done`,
       );
       return;
@@ -55,7 +55,7 @@ export class TokenCreateFtFromFileStateHook implements Hook<PostOutputPreparatio
     const normalisedParams = parseResult.data;
     const innerTransactionId = batchDataItem.transactionId;
     if (!innerTransactionId) {
-      logger.warn(
+      api.logger.warn(
         `No transaction ID found for batch transaction ${batchDataItem.order}`,
       );
       return;
@@ -67,7 +67,7 @@ export class TokenCreateFtFromFileStateHook implements Hook<PostOutputPreparatio
       });
 
     if (!innerTransactionResult.tokenId) {
-      logger.warn(
+      api.logger.warn(
         'Transaction completed but did not return a token ID, skipping state save',
       );
       return;
@@ -82,7 +82,7 @@ export class TokenCreateFtFromFileStateHook implements Hook<PostOutputPreparatio
       innerTransactionResult.tokenId,
       normalisedParams.associations,
       api,
-      logger,
+      api.logger,
       normalisedParams.keyManager,
     );
 
@@ -90,13 +90,13 @@ export class TokenCreateFtFromFileStateHook implements Hook<PostOutputPreparatio
       normalisedParams.network,
       innerTransactionResult.tokenId,
     );
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     tokenState.saveToken(key, tokenData);
-    logger.info('   Token data saved to state');
+    api.logger.info('   Token data saved to state');
 
     if (normalisedParams.alias) {
       if (api.alias.exists(normalisedParams.alias, normalisedParams.network)) {
-        logger.warn(
+        api.logger.warn(
           `Alias "${normalisedParams.alias}" already exists, skipping registration`,
         );
       } else {
@@ -107,7 +107,7 @@ export class TokenCreateFtFromFileStateHook implements Hook<PostOutputPreparatio
           entityId: innerTransactionResult.tokenId,
           createdAt: innerTransactionResult.consensusTimestamp,
         });
-        logger.info(`   Name registered: ${normalisedParams.alias}`);
+        api.logger.info(`   Name registered: ${normalisedParams.alias}`);
       }
     }
   }

--- a/src/plugins/token/hooks/token-create-ft-state/handler.ts
+++ b/src/plugins/token/hooks/token-create-ft-state/handler.ts
@@ -28,11 +28,13 @@ export class TokenCreateFtStateHook implements Hook<PostOutputPreparationHookPar
     if (!batchData.success) {
       return { breakFlow: false };
     }
-    const { api, logger } = params.args;
+    const { api } = params.args;
     await Promise.all(
       [...batchData.transactions]
         .filter((item) => item.command === TOKEN_CREATE_FT_COMMAND_NAME)
-        .map((batchDataItem) => this.saveCreateFt(api, logger, batchDataItem)),
+        .map((batchDataItem) =>
+          this.saveCreateFt(api, api.logger, batchDataItem),
+        ),
     );
     return { breakFlow: false };
   }
@@ -46,7 +48,7 @@ export class TokenCreateFtStateHook implements Hook<PostOutputPreparationHookPar
       batchDataItem.normalizedParams,
     );
     if (!parseResult.success) {
-      logger.warn(
+      api.logger.warn(
         `There was a problem with parsing data schema. The saving will not be done`,
       );
       return;
@@ -54,7 +56,7 @@ export class TokenCreateFtStateHook implements Hook<PostOutputPreparationHookPar
     const normalisedParams = parseResult.data;
     const innerTransactionId = batchDataItem.transactionId;
     if (!innerTransactionId) {
-      logger.warn(
+      api.logger.warn(
         `No transaction ID found for batch transaction ${batchDataItem.order}`,
       );
       return;
@@ -66,7 +68,7 @@ export class TokenCreateFtStateHook implements Hook<PostOutputPreparationHookPar
       });
 
     if (!innerTransactionResult.tokenId) {
-      logger.warn(
+      api.logger.warn(
         'Transaction completed but did not return a token ID, skipping state save',
       );
       return;
@@ -105,13 +107,13 @@ export class TokenCreateFtStateHook implements Hook<PostOutputPreparationHookPar
       normalisedParams.network,
       innerTransactionResult.tokenId,
     );
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     tokenState.saveToken(key, tokenData);
-    logger.info('   Token data saved to state');
+    api.logger.info('   Token data saved to state');
 
     if (normalisedParams.alias) {
       if (api.alias.exists(normalisedParams.alias, normalisedParams.network)) {
-        logger.warn(
+        api.logger.warn(
           `Alias "${normalisedParams.alias}" already exists, skipping registration`,
         );
       } else {
@@ -122,7 +124,7 @@ export class TokenCreateFtStateHook implements Hook<PostOutputPreparationHookPar
           entityId: innerTransactionResult.tokenId,
           createdAt: innerTransactionResult.consensusTimestamp,
         });
-        logger.info(`   Name registered: ${normalisedParams.alias}`);
+        api.logger.info(`   Name registered: ${normalisedParams.alias}`);
       }
     }
   }

--- a/src/plugins/token/hooks/token-create-ft-state/handler.ts
+++ b/src/plugins/token/hooks/token-create-ft-state/handler.ts
@@ -1,4 +1,4 @@
-import type { CoreApi, Logger } from '@/core';
+import type { CoreApi } from '@/core';
 import type { Hook, HookResult } from '@/core/hooks/hook.interface';
 import type { PostOutputPreparationHookParams } from '@/core/hooks/types';
 
@@ -32,16 +32,13 @@ export class TokenCreateFtStateHook implements Hook<PostOutputPreparationHookPar
     await Promise.all(
       [...batchData.transactions]
         .filter((item) => item.command === TOKEN_CREATE_FT_COMMAND_NAME)
-        .map((batchDataItem) =>
-          this.saveCreateFt(api, api.logger, batchDataItem),
-        ),
+        .map((batchDataItem) => this.saveCreateFt(api, batchDataItem)),
     );
     return { breakFlow: false };
   }
 
   private async saveCreateFt(
     api: CoreApi,
-    logger: Logger,
     batchDataItem: BatchDataItem,
   ): Promise<void> {
     const parseResult = CreateFtNormalizedParamsSchema.safeParse(

--- a/src/plugins/token/hooks/token-create-nft-from-file-state/handler.ts
+++ b/src/plugins/token/hooks/token-create-nft-from-file-state/handler.ts
@@ -27,14 +27,14 @@ export class TokenCreateNftFromFileStateHook implements Hook<PostOutputPreparati
       return { breakFlow: false };
     }
     const batchData = parsed.data.batchData;
-    const { api, logger } = params.args;
+    const { api } = params.args;
     if (!batchData.success) {
       return { breakFlow: false };
     }
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOKEN_CREATE_NFT_FROM_FILE_COMMAND_NAME,
     )) {
-      await this.saveNft(api, logger, batchDataItem);
+      await this.saveNft(api, api.logger, batchDataItem);
     }
     return { breakFlow: false };
   }
@@ -48,7 +48,7 @@ export class TokenCreateNftFromFileStateHook implements Hook<PostOutputPreparati
       batchDataItem.normalizedParams,
     );
     if (!parseResult.success) {
-      logger.warn(
+      api.logger.warn(
         `There was a problem with parsing data schema. The saving will not be done`,
       );
       return;
@@ -56,7 +56,7 @@ export class TokenCreateNftFromFileStateHook implements Hook<PostOutputPreparati
     const normalisedParams = parseResult.data;
     const innerTransactionId = batchDataItem.transactionId;
     if (!innerTransactionId) {
-      logger.warn(
+      api.logger.warn(
         `No transaction ID found for batch transaction ${batchDataItem.order}`,
       );
       return;
@@ -68,7 +68,7 @@ export class TokenCreateNftFromFileStateHook implements Hook<PostOutputPreparati
       });
 
     if (!innerTransactionResult.tokenId) {
-      logger.warn(
+      api.logger.warn(
         'Transaction completed but did not return a token ID, skipping state save',
       );
       return;
@@ -83,7 +83,7 @@ export class TokenCreateNftFromFileStateHook implements Hook<PostOutputPreparati
       innerTransactionResult.tokenId,
       normalisedParams.associations as Credential[],
       api,
-      logger,
+      api.logger,
       normalisedParams.keyManager,
     );
 
@@ -91,13 +91,13 @@ export class TokenCreateNftFromFileStateHook implements Hook<PostOutputPreparati
       normalisedParams.network,
       innerTransactionResult.tokenId,
     );
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     tokenState.saveToken(key, tokenData);
-    logger.info('   Non-fungible token data saved to state');
+    api.logger.info('   Non-fungible token data saved to state');
 
     if (normalisedParams.alias) {
       if (api.alias.exists(normalisedParams.alias, normalisedParams.network)) {
-        logger.warn(
+        api.logger.warn(
           `Alias "${normalisedParams.alias}" already exists, skipping registration`,
         );
       } else {
@@ -108,7 +108,7 @@ export class TokenCreateNftFromFileStateHook implements Hook<PostOutputPreparati
           entityId: innerTransactionResult.tokenId,
           createdAt: innerTransactionResult.consensusTimestamp,
         });
-        logger.info(`   Name registered: ${normalisedParams.alias}`);
+        api.logger.info(`   Name registered: ${normalisedParams.alias}`);
       }
     }
   }

--- a/src/plugins/token/hooks/token-create-nft-from-file-state/handler.ts
+++ b/src/plugins/token/hooks/token-create-nft-from-file-state/handler.ts
@@ -1,4 +1,4 @@
-import type { CoreApi, Logger } from '@/core';
+import type { CoreApi } from '@/core';
 import type { Hook, HookResult } from '@/core/hooks/hook.interface';
 import type { PostOutputPreparationHookParams } from '@/core/hooks/types';
 import type { Credential } from '@/core/services/kms/kms-types.interface';
@@ -34,14 +34,13 @@ export class TokenCreateNftFromFileStateHook implements Hook<PostOutputPreparati
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOKEN_CREATE_NFT_FROM_FILE_COMMAND_NAME,
     )) {
-      await this.saveNft(api, api.logger, batchDataItem);
+      await this.saveNft(api, batchDataItem);
     }
     return { breakFlow: false };
   }
 
   private async saveNft(
     api: CoreApi,
-    logger: Logger,
     batchDataItem: BatchDataItem,
   ): Promise<void> {
     const parseResult = CreateNftFromFileNormalizedParamsSchema.safeParse(
@@ -83,7 +82,6 @@ export class TokenCreateNftFromFileStateHook implements Hook<PostOutputPreparati
       innerTransactionResult.tokenId,
       normalisedParams.associations as Credential[],
       api,
-      api.logger,
       normalisedParams.keyManager,
     );
 

--- a/src/plugins/token/hooks/token-create-nft-state/handler.ts
+++ b/src/plugins/token/hooks/token-create-nft-state/handler.ts
@@ -28,11 +28,11 @@ export class TokenCreateNftStateHook implements Hook<PostOutputPreparationHookPa
     if (!batchData.success) {
       return { breakFlow: false };
     }
-    const { api, logger } = params.args;
+    const { api } = params.args;
     await Promise.all(
       [...batchData.transactions]
         .filter((item) => item.command === TOKEN_CREATE_NFT_COMMAND_NAME)
-        .map((batchDataItem) => this.saveNft(api, logger, batchDataItem)),
+        .map((batchDataItem) => this.saveNft(api, api.logger, batchDataItem)),
     );
     return { breakFlow: false };
   }
@@ -46,7 +46,7 @@ export class TokenCreateNftStateHook implements Hook<PostOutputPreparationHookPa
       batchDataItem.normalizedParams,
     );
     if (!parseResult.success) {
-      logger.warn(
+      api.logger.warn(
         `There was a problem with parsing data schema. The saving will not be done`,
       );
       return;
@@ -54,7 +54,7 @@ export class TokenCreateNftStateHook implements Hook<PostOutputPreparationHookPa
     const normalisedParams = parseResult.data;
     const innerTransactionId = batchDataItem.transactionId;
     if (!innerTransactionId) {
-      logger.warn(
+      api.logger.warn(
         `No transaction ID found for batch transaction ${batchDataItem.order}`,
       );
       return;
@@ -66,7 +66,7 @@ export class TokenCreateNftStateHook implements Hook<PostOutputPreparationHookPa
       });
 
     if (!innerTransactionResult.tokenId) {
-      logger.warn(
+      api.logger.warn(
         'Transaction completed but did not return a token ID, skipping state save',
       );
       return;
@@ -105,13 +105,13 @@ export class TokenCreateNftStateHook implements Hook<PostOutputPreparationHookPa
       normalisedParams.network,
       innerTransactionResult.tokenId,
     );
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     tokenState.saveToken(key, tokenData);
-    logger.info('   Non-fungible token data saved to state');
+    api.logger.info('   Non-fungible token data saved to state');
 
     if (normalisedParams.alias) {
       if (api.alias.exists(normalisedParams.alias, normalisedParams.network)) {
-        logger.warn(
+        api.logger.warn(
           `Alias "${normalisedParams.alias}" already exists, skipping registration`,
         );
       } else {
@@ -122,7 +122,7 @@ export class TokenCreateNftStateHook implements Hook<PostOutputPreparationHookPa
           entityId: innerTransactionResult.tokenId,
           createdAt: innerTransactionResult.consensusTimestamp,
         });
-        logger.info(`   Name registered: ${normalisedParams.alias}`);
+        api.logger.info(`   Name registered: ${normalisedParams.alias}`);
       }
     }
   }

--- a/src/plugins/token/hooks/token-create-nft-state/handler.ts
+++ b/src/plugins/token/hooks/token-create-nft-state/handler.ts
@@ -1,4 +1,4 @@
-import type { CoreApi, Logger } from '@/core';
+import type { CoreApi } from '@/core';
 import type { Hook, HookResult } from '@/core/hooks/hook.interface';
 import type { PostOutputPreparationHookParams } from '@/core/hooks/types';
 
@@ -32,14 +32,13 @@ export class TokenCreateNftStateHook implements Hook<PostOutputPreparationHookPa
     await Promise.all(
       [...batchData.transactions]
         .filter((item) => item.command === TOKEN_CREATE_NFT_COMMAND_NAME)
-        .map((batchDataItem) => this.saveNft(api, api.logger, batchDataItem)),
+        .map((batchDataItem) => this.saveNft(api, batchDataItem)),
     );
     return { breakFlow: false };
   }
 
   private async saveNft(
     api: CoreApi,
-    logger: Logger,
     batchDataItem: BatchDataItem,
   ): Promise<void> {
     const parseResult = CreateNftNormalizedParamsSchema.safeParse(

--- a/src/plugins/token/hooks/token-delete-state/handler.ts
+++ b/src/plugins/token/hooks/token-delete-state/handler.ts
@@ -21,7 +21,7 @@ export class TokenDeleteStateHook implements Hook<PostOutputPreparationHookParam
       return Promise.resolve({ breakFlow: false });
     }
     const batchData = parsed.data.batchData;
-    const { api, logger } = params.args;
+    const { api } = params.args;
 
     if (!batchData.success) {
       return Promise.resolve({ breakFlow: false });
@@ -30,7 +30,7 @@ export class TokenDeleteStateHook implements Hook<PostOutputPreparationHookParam
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOKEN_DELETE_COMMAND_NAME,
     )) {
-      this.cleanupState(api, logger, batchDataItem);
+      this.cleanupState(api, api.logger, batchDataItem);
     }
 
     return Promise.resolve({ breakFlow: false });
@@ -46,12 +46,14 @@ export class TokenDeleteStateHook implements Hook<PostOutputPreparationHookParam
     );
 
     if (!parseResult.success) {
-      logger.warn('Problem parsing delete batch data. State cleanup skipped.');
+      api.logger.warn(
+        'Problem parsing delete batch data. State cleanup skipped.',
+      );
       return;
     }
 
     const { network, tokenId } = parseResult.data;
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const key = composeKey(network, tokenId);
     const tokenInState = tokenState.getToken(key);
 
@@ -66,6 +68,6 @@ export class TokenDeleteStateHook implements Hook<PostOutputPreparationHookParam
     }
 
     tokenState.removeToken(key);
-    logger.debug(`Cleaned up state for deleted token ${tokenId}`);
+    api.logger.debug(`Cleaned up state for deleted token ${tokenId}`);
   }
 }

--- a/src/plugins/token/hooks/token-delete-state/handler.ts
+++ b/src/plugins/token/hooks/token-delete-state/handler.ts
@@ -1,4 +1,4 @@
-import type { CoreApi, Logger } from '@/core';
+import type { CoreApi } from '@/core';
 import type { Hook, HookResult } from '@/core/hooks/hook.interface';
 import type { PostOutputPreparationHookParams } from '@/core/hooks/types';
 import type { BatchDataItem } from '@/core/types/shared.types';
@@ -30,17 +30,13 @@ export class TokenDeleteStateHook implements Hook<PostOutputPreparationHookParam
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOKEN_DELETE_COMMAND_NAME,
     )) {
-      this.cleanupState(api, api.logger, batchDataItem);
+      this.cleanupState(api, batchDataItem);
     }
 
     return Promise.resolve({ breakFlow: false });
   }
 
-  private cleanupState(
-    api: CoreApi,
-    logger: Logger,
-    batchDataItem: BatchDataItem,
-  ): void {
+  private cleanupState(api: CoreApi, batchDataItem: BatchDataItem): void {
     const parseResult = DeleteNormalizedParamsSchema.safeParse(
       batchDataItem.normalizedParams,
     );

--- a/src/plugins/token/hooks/token-dissociate-state/handler.ts
+++ b/src/plugins/token/hooks/token-dissociate-state/handler.ts
@@ -1,4 +1,4 @@
-import type { CoreApi, Logger } from '@/core';
+import type { CoreApi } from '@/core';
 import type { Hook, HookResult } from '@/core/hooks/hook.interface';
 import type { PostOutputPreparationHookParams } from '@/core/hooks/types';
 import type { BatchDataItem } from '@/core/types/shared.types';
@@ -31,16 +31,12 @@ export class TokenDissociateStateHook implements Hook<PostOutputPreparationHookP
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOKEN_DISSOCIATE_COMMAND_NAME,
     )) {
-      this.removeAssociations(api, api.logger, batchDataItem);
+      this.removeAssociations(api, batchDataItem);
     }
     return Promise.resolve({ breakFlow: false });
   }
 
-  private removeAssociations(
-    api: CoreApi,
-    logger: Logger,
-    batchDataItem: BatchDataItem,
-  ): void {
+  private removeAssociations(api: CoreApi, batchDataItem: BatchDataItem): void {
     const parseResult = DissociateNormalizedParamsSchema.safeParse(
       batchDataItem.normalizedParams,
     );

--- a/src/plugins/token/hooks/token-dissociate-state/handler.ts
+++ b/src/plugins/token/hooks/token-dissociate-state/handler.ts
@@ -24,14 +24,14 @@ export class TokenDissociateStateHook implements Hook<PostOutputPreparationHookP
       return Promise.resolve({ breakFlow: false });
     }
     const batchData = orchestratorResult.batchData;
-    const { api, logger } = params.args;
+    const { api } = params.args;
     if (!batchData.success) {
       return Promise.resolve({ breakFlow: false });
     }
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOKEN_DISSOCIATE_COMMAND_NAME,
     )) {
-      this.removeAssociations(api, logger, batchDataItem);
+      this.removeAssociations(api, api.logger, batchDataItem);
     }
     return Promise.resolve({ breakFlow: false });
   }
@@ -45,20 +45,20 @@ export class TokenDissociateStateHook implements Hook<PostOutputPreparationHookP
       batchDataItem.normalizedParams,
     );
     if (!parseResult.success) {
-      logger.warn(
+      api.logger.warn(
         `There was a problem with parsing data schema. The saving will not be done`,
       );
       return;
     }
     const normalisedParams = parseResult.data;
 
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     removeAssociationFromState(
       tokenState,
       normalisedParams.tokenId,
       normalisedParams.account.accountId,
       normalisedParams.network,
-      logger,
+      api.logger,
     );
   }
 }

--- a/src/plugins/token/hooks/token-update-state/handler.ts
+++ b/src/plugins/token/hooks/token-update-state/handler.ts
@@ -1,4 +1,4 @@
-import type { CoreApi, Logger } from '@/core';
+import type { CoreApi } from '@/core';
 import type { Hook, HookResult } from '@/core/hooks/hook.interface';
 import type { PostOutputPreparationHookParams } from '@/core/hooks/types';
 import type { BatchDataItem } from '@/core/types/shared.types';
@@ -29,17 +29,13 @@ export class TokenUpdateStateHook implements Hook<PostOutputPreparationHookParam
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOKEN_UPDATE_COMMAND_NAME,
     )) {
-      this.updateTokenState(api, api.logger, batchDataItem);
+      this.updateTokenState(api, batchDataItem);
     }
 
     return Promise.resolve({ breakFlow: false });
   }
 
-  private updateTokenState(
-    api: CoreApi,
-    logger: Logger,
-    batchDataItem: BatchDataItem,
-  ): void {
+  private updateTokenState(api: CoreApi, batchDataItem: BatchDataItem): void {
     const parseResult = TokenUpdateNormalisedParamsSchema.safeParse(
       batchDataItem.normalizedParams,
     );

--- a/src/plugins/token/hooks/token-update-state/handler.ts
+++ b/src/plugins/token/hooks/token-update-state/handler.ts
@@ -20,7 +20,7 @@ export class TokenUpdateStateHook implements Hook<PostOutputPreparationHookParam
       return Promise.resolve({ breakFlow: false });
     }
     const batchData = parsed.data.batchData;
-    const { api, logger } = params.args;
+    const { api } = params.args;
 
     if (!batchData.success) {
       return Promise.resolve({ breakFlow: false });
@@ -29,7 +29,7 @@ export class TokenUpdateStateHook implements Hook<PostOutputPreparationHookParam
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOKEN_UPDATE_COMMAND_NAME,
     )) {
-      this.updateTokenState(api, logger, batchDataItem);
+      this.updateTokenState(api, api.logger, batchDataItem);
     }
 
     return Promise.resolve({ breakFlow: false });
@@ -45,19 +45,19 @@ export class TokenUpdateStateHook implements Hook<PostOutputPreparationHookParam
     );
 
     if (!parseResult.success) {
-      logger.warn(
+      api.logger.warn(
         'There was a problem with parsing data schema. The saving will not be done',
       );
       return;
     }
 
     const p = parseResult.data;
-    const tokenState = new ZustandTokenStateHelper(api.state, logger);
+    const tokenState = new ZustandTokenStateHelper(api.state, api.logger);
     const existing = tokenState.getToken(p.stateKey);
 
     const tokenData = buildUpdatedTokenData(p, p.tokenInfo, existing);
 
     tokenState.saveToken(p.stateKey, tokenData);
-    logger.info(`   Token update state saved for ${p.tokenId}`);
+    api.logger.info(`   Token update state saved for ${p.tokenId}`);
   }
 }

--- a/src/plugins/token/utils/token-associations.ts
+++ b/src/plugins/token/utils/token-associations.ts
@@ -45,14 +45,13 @@ export async function processTokenAssociations(
   tokenId: string,
   associations: Credential[],
   api: CoreApi,
-  logger: Logger,
   keyManager: KeyManager,
 ): Promise<Array<{ name: string; accountId: string }>> {
   if (associations.length === 0) {
     return [];
   }
 
-  logger.info(`   Creating ${associations.length} token associations...`);
+  api.logger.info(`   Creating ${associations.length} token associations...`);
   const successfulAssociations: Array<{ name: string; accountId: string }> = [];
 
   for (const association of associations) {
@@ -75,16 +74,22 @@ export async function processTokenAssociations(
       const associateResult = await api.txExecute.execute(transaction);
 
       if (associateResult.success) {
-        logger.info(`   ✅ Associated account ${account.accountId} with token`);
+        api.logger.info(
+          `   ✅ Associated account ${account.accountId} with token`,
+        );
         successfulAssociations.push({
           name: account.accountId,
           accountId: account.accountId,
         });
       } else {
-        logger.warn(`   ⚠️  Failed to associate account ${account.accountId}`);
+        api.logger.warn(
+          `   ⚠️  Failed to associate account ${account.accountId}`,
+        );
       }
     } catch {
-      logger.warn(`   ⚠️  Failed to associate account ${association.rawValue}`);
+      api.logger.warn(
+        `   ⚠️  Failed to associate account ${association.rawValue}`,
+      );
     }
   }
 

--- a/src/plugins/topic/commands/create/handler.ts
+++ b/src/plugins/topic/commands/create/handler.ts
@@ -33,7 +33,7 @@ export class TopicCreateCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<CreateTopicNormalisedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TopicCreateInputSchema.parse(args.args);
 
     const memo = validArgs.memo;
@@ -50,7 +50,7 @@ export class TopicCreateCommand extends BaseTransactionCommand<
       api.config.getOption<KeyManager>(ConfigOptionKey.default_key_manager);
 
     if (memo) {
-      logger.info(`Creating topic with memo: ${memo}`);
+      api.logger.info(`Creating topic with memo: ${memo}`);
     }
 
     const adminKeys = await Promise.all(
@@ -159,8 +159,8 @@ export class TopicCreateCommand extends BaseTransactionCommand<
     _signTransactionResult: CreateTopicSignTransactionResult,
     executeTransactionResult: CreateTopicExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
-    const topicState = new ZustandTopicStateHelper(api.state, logger);
+    const { api } = args;
+    const topicState = new ZustandTopicStateHelper(api.state, api.logger);
     const topicId = executeTransactionResult.topicId;
     if (!topicId) {
       throw new TransactionError(

--- a/src/plugins/topic/commands/delete/handler.ts
+++ b/src/plugins/topic/commands/delete/handler.ts
@@ -47,9 +47,9 @@ export class TopicDeleteCommand extends BaseTransactionCommand<
   private async executeStateOnlyDelete(
     args: CommandHandlerArgs,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
     const params = await this.resolveStateTopicForDelete(args);
-    const topicHelper = new TopicHelper(api.alias, api.state, logger);
+    const topicHelper = new TopicHelper(api.alias, api.state, api.logger);
     const removedAliases = topicHelper.removeTopicFromLocalState(
       params.topicToDelete,
       params.network,
@@ -71,8 +71,8 @@ export class TopicDeleteCommand extends BaseTransactionCommand<
   private async resolveStateTopicForDelete(
     args: CommandHandlerArgs,
   ): Promise<DeleteTopicNormalisedParams> {
-    const { api, logger } = args;
-    const topicState = new ZustandTopicStateHelper(api.state, logger);
+    const { api } = args;
+    const topicState = new ZustandTopicStateHelper(api.state, api.logger);
     const validArgs = TopicDeleteInputSchema.parse(args.args);
     const topicRef = validArgs.topic;
     const isEntityId = EntityIdSchema.safeParse(topicRef).success;
@@ -136,12 +136,12 @@ export class TopicDeleteCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<DeleteTopicNormalisedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TopicDeleteInputSchema.parse(args.args);
     const network = api.network.getCurrentNetwork();
     const topicRef = validArgs.topic;
     const isEntityId = EntityIdSchema.safeParse(topicRef).success;
-    const topicState = new ZustandTopicStateHelper(api.state, logger);
+    const topicState = new ZustandTopicStateHelper(api.state, api.logger);
     const keyManager =
       validArgs.keyManager ||
       api.config.getOption<KeyManager>(ConfigOptionKey.default_key_manager);
@@ -252,7 +252,7 @@ export class TopicDeleteCommand extends BaseTransactionCommand<
     _signTransactionResult: DeleteTopicSignTransactionResult,
     executeTransactionResult: DeleteTopicExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
     if (!executeTransactionResult.success) {
       throw new TransactionError(
@@ -267,7 +267,7 @@ export class TopicDeleteCommand extends BaseTransactionCommand<
       );
     }
 
-    const topicHelper = new TopicHelper(api.alias, api.state, logger);
+    const topicHelper = new TopicHelper(api.alias, api.state, api.logger);
     const removedAliases = topicHelper.removeTopicFromLocalState(
       normalisedParams.topicToDelete,
       normalisedParams.network,

--- a/src/plugins/topic/commands/find-message/handler.ts
+++ b/src/plugins/topic/commands/find-message/handler.ts
@@ -11,7 +11,7 @@ import { TopicFindMessageInputSchema } from './input';
 
 export class TopicFindMessageCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
     const validParams = TopicFindMessageInputSchema.parse(args.args);
     const currentNetwork = api.network.getCurrentNetwork();
@@ -27,7 +27,7 @@ export class TopicFindMessageCommand implements Command {
       currentNetwork,
     };
 
-    logger.info(`Finding messages in topic: ${normalisedParams.topicId}`);
+    api.logger.info(`Finding messages in topic: ${normalisedParams.topicId}`);
 
     const apiFilters = buildApiFilters(validParams);
     const messages = await fetchFilteredMessages(

--- a/src/plugins/topic/commands/import/handler.ts
+++ b/src/plugins/topic/commands/import/handler.ts
@@ -16,9 +16,9 @@ import { TopicImportInputSchema } from './input';
 
 export class TopicImportCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const topicState = new ZustandTopicStateHelper(api.state, logger);
+    const topicState = new ZustandTopicStateHelper(api.state, api.logger);
     const validArgs = TopicImportInputSchema.parse(args.args);
     const network = api.network.getCurrentNetwork();
 
@@ -38,7 +38,7 @@ export class TopicImportCommand implements Command {
     const topicInfo = await api.mirror.getTopicInfo(normalisedParams.topicId);
     const key = composeKey(normalisedParams.network, normalisedParams.topicId);
 
-    logger.info(`Importing topic: ${key} (${normalisedParams.topicId})`);
+    api.logger.info(`Importing topic: ${key} (${normalisedParams.topicId})`);
 
     if (topicState.loadTopic(key)) {
       throw new ValidationError(

--- a/src/plugins/topic/commands/list/handler.ts
+++ b/src/plugins/topic/commands/list/handler.ts
@@ -9,15 +9,15 @@ import { TopicListInputSchema } from './input';
 
 export class TopicListCommand implements Command {
   async execute(args: CommandHandlerArgs): Promise<CommandResult> {
-    const { api, logger } = args;
+    const { api } = args;
 
-    const topicState = new ZustandTopicStateHelper(api.state, logger);
+    const topicState = new ZustandTopicStateHelper(api.state, api.logger);
     const validArgs = TopicListInputSchema.parse(args.args);
     const normalisedParams: ListTopicsNormalisedParams = {
       networkFilter: validArgs.network,
     };
 
-    logger.info('Listing topics...');
+    api.logger.info('Listing topics...');
 
     let topics = topicState.listTopics();
 

--- a/src/plugins/topic/commands/submit-message/handler.ts
+++ b/src/plugins/topic/commands/submit-message/handler.ts
@@ -38,10 +38,10 @@ export class TopicSubmitMessageCommand extends BaseTransactionCommand<
     keyManager: KeyManager,
     topicId: string,
   ): Promise<string[]> {
-    const { api, logger } = args;
+    const { api } = args;
 
     if (!topicInfo.submit_key) {
-      logger.info(`Submitting to public topic (no submit key required)`);
+      api.logger.info(`Submitting to public topic (no submit key required)`);
       return [];
     }
 
@@ -55,14 +55,14 @@ export class TopicSubmitMessageCommand extends BaseTransactionCommand<
         'Not enough submit key(s) found in key manager for this topic. Provide --signer.',
       validationErrorOptions: { context: { topicId } },
     });
-    logger.info(`Using ${keyRefIds.length} signer(s) for submit key`);
+    api.logger.info(`Using ${keyRefIds.length} signer(s) for submit key`);
     return keyRefIds;
   }
 
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<SubmitMessageNormalisedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TopicSubmitMessageInputSchema.parse(args.args);
 
     const topicIdOrAlias = validArgs.topic;
@@ -83,7 +83,7 @@ export class TopicSubmitMessageCommand extends BaseTransactionCommand<
     if (topicAliasResult?.entityId) {
       topicId = topicAliasResult.entityId;
     }
-    logger.info(`Submitting message to topic: ${topicId}`);
+    api.logger.info(`Submitting message to topic: ${topicId}`);
 
     const topicInfo = await api.mirror.getTopicInfo(topicId);
     const signerKeyRefIds = await this.resolveSubmitSigners(

--- a/src/plugins/topic/commands/update/handler.ts
+++ b/src/plugins/topic/commands/update/handler.ts
@@ -44,14 +44,14 @@ export class TopicUpdateCommand extends BaseTransactionCommand<
   async normalizeParams(
     args: CommandHandlerArgs,
   ): Promise<UpdateTopicNormalisedParams> {
-    const { api, logger } = args;
+    const { api } = args;
     const validArgs = TopicUpdateInputSchema.parse(args.args);
 
     const network = api.network.getCurrentNetwork();
     const topicId = resolveTopicId(validArgs.topic, api.alias, network);
 
     const stateKey = composeKey(network, topicId);
-    const topicState = new ZustandTopicStateHelper(api.state, logger);
+    const topicState = new ZustandTopicStateHelper(api.state, api.logger);
     const storedTopicData = topicState.loadTopic(stateKey);
     if (!storedTopicData) {
       throw new NotFoundError(
@@ -136,7 +136,7 @@ export class TopicUpdateCommand extends BaseTransactionCommand<
       currentAdminKeyRefIds = keyRefIds;
     }
 
-    logger.info(`Updating topic ${topicId} on ${network}`);
+    api.logger.info(`Updating topic ${topicId} on ${network}`);
 
     return {
       topicId,
@@ -264,8 +264,8 @@ export class TopicUpdateCommand extends BaseTransactionCommand<
     _signTransactionResult: UpdateTopicSignTransactionResult,
     executeTransactionResult: UpdateTopicExecuteTransactionResult,
   ): Promise<CommandResult> {
-    const { api, logger } = args;
-    const topicState = new ZustandTopicStateHelper(api.state, logger);
+    const { api } = args;
+    const topicState = new ZustandTopicStateHelper(api.state, api.logger);
     const existing = normalisedParams.existingTopicData;
 
     const updatedFields: string[] = [];

--- a/src/plugins/topic/hooks/topic-create-state/handler.ts
+++ b/src/plugins/topic/hooks/topic-create-state/handler.ts
@@ -24,14 +24,14 @@ export class TopicCreateStateHook implements Hook<PostOutputPreparationHookParam
       return { breakFlow: false };
     }
     const batchData = parsed.data.batchData;
-    const { api, logger } = params.args;
+    const { api } = params.args;
     if (!batchData.success) {
       return { breakFlow: false };
     }
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOPIC_CREATE_COMMAND_NAME,
     )) {
-      await this.saveTopic(api, logger, batchDataItem);
+      await this.saveTopic(api, api.logger, batchDataItem);
     }
     return { breakFlow: false };
   }
@@ -45,7 +45,7 @@ export class TopicCreateStateHook implements Hook<PostOutputPreparationHookParam
       batchDataItem.normalizedParams,
     );
     if (!parseResult.success) {
-      logger.warn(
+      api.logger.warn(
         `There was a problem with parsing data schema. The saving will not be done`,
       );
       return;
@@ -53,7 +53,7 @@ export class TopicCreateStateHook implements Hook<PostOutputPreparationHookParam
     const normalisedParams = parseResult.data;
     const innerTransactionId = batchDataItem.transactionId;
     if (!innerTransactionId) {
-      logger.warn(
+      api.logger.warn(
         `No transaction ID found for batch transaction ${batchDataItem.order}`,
       );
       return;
@@ -65,7 +65,7 @@ export class TopicCreateStateHook implements Hook<PostOutputPreparationHookParam
       });
 
     if (!innerTransactionResult.topicId) {
-      logger.warn(
+      api.logger.warn(
         'Transaction completed but did not return a topic ID, skipping state save',
       );
       return;
@@ -77,7 +77,7 @@ export class TopicCreateStateHook implements Hook<PostOutputPreparationHookParam
 
     if (normalisedParams.alias) {
       if (api.alias.exists(normalisedParams.alias, normalisedParams.network)) {
-        logger.warn(
+        api.logger.warn(
           `Alias "${normalisedParams.alias}" already exists, skipping registration`,
         );
       } else {
@@ -104,7 +104,7 @@ export class TopicCreateStateHook implements Hook<PostOutputPreparationHookParam
     };
 
     const key = composeKey(normalisedParams.network, topicId);
-    const topicState = new ZustandTopicStateHelper(api.state, logger);
+    const topicState = new ZustandTopicStateHelper(api.state, api.logger);
     topicState.saveTopic(key, topicData);
   }
 }

--- a/src/plugins/topic/hooks/topic-create-state/handler.ts
+++ b/src/plugins/topic/hooks/topic-create-state/handler.ts
@@ -1,4 +1,4 @@
-import type { CoreApi, Logger } from '@/core';
+import type { CoreApi } from '@/core';
 import type { Hook, HookResult } from '@/core/hooks/hook.interface';
 import type { PostOutputPreparationHookParams } from '@/core/hooks/types';
 
@@ -31,14 +31,13 @@ export class TopicCreateStateHook implements Hook<PostOutputPreparationHookParam
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOPIC_CREATE_COMMAND_NAME,
     )) {
-      await this.saveTopic(api, api.logger, batchDataItem);
+      await this.saveTopic(api, batchDataItem);
     }
     return { breakFlow: false };
   }
 
   private async saveTopic(
     api: CoreApi,
-    logger: Logger,
     batchDataItem: BatchDataItem,
   ): Promise<void> {
     const parseResult = TopicCreateNormalisedParamsSchema.safeParse(

--- a/src/plugins/topic/hooks/topic-delete-state/handler.ts
+++ b/src/plugins/topic/hooks/topic-delete-state/handler.ts
@@ -19,14 +19,14 @@ export class TopicDeleteStateHook implements Hook<PostOutputPreparationHookParam
       return Promise.resolve({ breakFlow: false });
     }
     const batchData = parsed.data.batchData;
-    const { api, logger } = params.args;
+    const { api } = params.args;
     if (!batchData.success) {
       return Promise.resolve({ breakFlow: false });
     }
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOPIC_DELETE_COMMAND_NAME,
     )) {
-      this.applyDeleteFromBatchItem(api, logger, batchDataItem);
+      this.applyDeleteFromBatchItem(api, api.logger, batchDataItem);
     }
     return Promise.resolve({ breakFlow: false });
   }
@@ -40,7 +40,7 @@ export class TopicDeleteStateHook implements Hook<PostOutputPreparationHookParam
       batchDataItem.normalizedParams,
     );
     if (!parseResult.success) {
-      logger.warn(
+      api.logger.warn(
         'Topic delete batch item skipped: normalized params did not match schema',
       );
       return;
@@ -49,7 +49,7 @@ export class TopicDeleteStateHook implements Hook<PostOutputPreparationHookParam
     if (normalised.stateOnly) {
       return;
     }
-    const topicHelper = new TopicHelper(api.alias, api.state, logger);
+    const topicHelper = new TopicHelper(api.alias, api.state, api.logger);
     topicHelper.removeTopicFromLocalState(
       normalised.topicToDelete,
       normalised.network,

--- a/src/plugins/topic/hooks/topic-delete-state/handler.ts
+++ b/src/plugins/topic/hooks/topic-delete-state/handler.ts
@@ -1,4 +1,4 @@
-import type { CoreApi, Logger } from '@/core';
+import type { CoreApi } from '@/core';
 import type { Hook, HookResult } from '@/core/hooks/hook.interface';
 import type { PostOutputPreparationHookParams } from '@/core/hooks/types';
 import type { BatchDataItem } from '@/core/types/shared.types';
@@ -26,14 +26,13 @@ export class TopicDeleteStateHook implements Hook<PostOutputPreparationHookParam
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOPIC_DELETE_COMMAND_NAME,
     )) {
-      this.applyDeleteFromBatchItem(api, api.logger, batchDataItem);
+      this.applyDeleteFromBatchItem(api, batchDataItem);
     }
     return Promise.resolve({ breakFlow: false });
   }
 
   private applyDeleteFromBatchItem(
     api: CoreApi,
-    logger: Logger,
     batchDataItem: BatchDataItem,
   ): void {
     const parseResult = TopicDeleteNormalisedParamsSchema.safeParse(

--- a/src/plugins/topic/hooks/topic-update-state/handler.ts
+++ b/src/plugins/topic/hooks/topic-update-state/handler.ts
@@ -1,4 +1,4 @@
-import type { CoreApi, Logger } from '@/core';
+import type { CoreApi } from '@/core';
 import type { Hook, HookResult } from '@/core/hooks/hook.interface';
 import type { PostOutputPreparationHookParams } from '@/core/hooks/types';
 import type { BatchDataItem } from '@/core/types/shared.types';
@@ -29,17 +29,13 @@ export class TopicUpdateStateHook implements Hook<PostOutputPreparationHookParam
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOPIC_UPDATE_COMMAND_NAME,
     )) {
-      this.updateTopicState(api, api.logger, batchDataItem);
+      this.updateTopicState(api, batchDataItem);
     }
 
     return Promise.resolve({ breakFlow: false });
   }
 
-  private updateTopicState(
-    api: CoreApi,
-    logger: Logger,
-    batchDataItem: BatchDataItem,
-  ): void {
+  private updateTopicState(api: CoreApi, batchDataItem: BatchDataItem): void {
     const parseResult = TopicUpdateNormalisedParamsSchema.safeParse(
       batchDataItem.normalizedParams,
     );

--- a/src/plugins/topic/hooks/topic-update-state/handler.ts
+++ b/src/plugins/topic/hooks/topic-update-state/handler.ts
@@ -20,7 +20,7 @@ export class TopicUpdateStateHook implements Hook<PostOutputPreparationHookParam
       return Promise.resolve({ breakFlow: false });
     }
     const batchData = parsed.data.batchData;
-    const { api, logger } = params.args;
+    const { api } = params.args;
 
     if (!batchData.success) {
       return Promise.resolve({ breakFlow: false });
@@ -29,7 +29,7 @@ export class TopicUpdateStateHook implements Hook<PostOutputPreparationHookParam
     for (const batchDataItem of [...batchData.transactions].filter(
       (item) => item.command === TOPIC_UPDATE_COMMAND_NAME,
     )) {
-      this.updateTopicState(api, logger, batchDataItem);
+      this.updateTopicState(api, api.logger, batchDataItem);
     }
 
     return Promise.resolve({ breakFlow: false });
@@ -45,7 +45,7 @@ export class TopicUpdateStateHook implements Hook<PostOutputPreparationHookParam
     );
 
     if (!parseResult.success) {
-      logger.warn(
+      api.logger.warn(
         `There was a problem with parsing data schema. The saving will not be done`,
       );
       return;
@@ -109,7 +109,7 @@ export class TopicUpdateStateHook implements Hook<PostOutputPreparationHookParam
     };
 
     const stateKey = composeKey(p.network, p.topicId);
-    const topicState = new ZustandTopicStateHelper(api.state, logger);
+    const topicState = new ZustandTopicStateHelper(api.state, api.logger);
     topicState.saveTopic(stateKey, updatedTopicData);
   }
 }


### PR DESCRIPTION
Issue #1692 

BREAKING CHANGE: CommandHandlerArgs no longer has top-level `state`, `logger` or `config` fields.
